### PR TITLE
Flatten event processing in DB checking pipeline

### DIFF
--- a/abft/event_processing.go
+++ b/abft/event_processing.go
@@ -48,6 +48,13 @@ func (p *Orderer) Process(e dag.Event) (err error) {
 	return err
 }
 
+func (p *Orderer) getSelfParentFrame(e dag.Event) idx.Frame {
+	if e.SelfParent() == nil {
+		return 0
+	}
+	return p.input.GetEvent(*e.SelfParent()).Frame()
+}
+
 // checkAndSaveEvent checks consensus-related fields: Frame, IsRoot
 func (p *Orderer) checkAndSaveEvent(e dag.Event) (error, idx.Frame) {
 	// check frame & isRoot


### PR DESCRIPTION
This PR creates a custom pipeline of event processing that simulates the real lifecycle of an event in Consensus.
Previously, we used `Build` and `Process` testing wrappers that were created for a variety of testing use cases and preformed some duplicated work, i.e. indexing and frame calculation, when called in sequence.

Having the event processing flattened with minimal duplications prepares the tool for a more realistic performance comparisons between the consensus upgrades. 