### PR TITLE
Replace Fantom module name w/Sonic & small migration adjustments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Golang files:
-*.go @andrecronje @Tjofil @psubotic
+*.go @Tjofil @psubotic @aksonic @kmeeth

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: '1.20'
+  go: "1.20"
   timeout: 20m
   tests: true
   skip-dirs-use-default: true
@@ -75,7 +75,7 @@ linters-settings:
     numbers: true
 
   goimports:
-    local-prefixes: github.com/Fantom-foundation/lachesis-base
+    local-prefixes: github.com/0xsoniclabs/consensus
 
   nestif:
     min-complexity: 5

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ before:
     - make clean proto vendor
 builds:
   - main: ./cmd/lachesis/main.go
-    binary: lachesis-base
+    binary: consensus
     ldflags:
       - -linkmode external -extldflags -static -s -w
       - -X main.gitCommit={{ .ShortCommit }}
@@ -21,15 +21,15 @@ archive:
     386: i386
     amd64: x86_64
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - "^docs:"
+      - "^test:"
 nfpm:
   name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
   replacements:
@@ -38,8 +38,8 @@ nfpm:
     darwin: macOS
     linux: Tux
 
-  vendor: Fanton Foundation
-  homepage: https://fantom.foundation
+  vendor: Sonic Labs
+  homepage: https://soniclabs.com
   maintainer: Samuel Marks <samuel@fantom.foundation>
   description: BFT Consensus platform for distributed applications.
   license: MIT
@@ -49,10 +49,10 @@ nfpm:
     - rpm
 
   empty_folders:
-    - /var/log/lachesis-base
+    - /var/log/consensus
 
   files:
-    "scripts/daemon/lachesis-base.service": "/lib/systemd/system/lachesis-base.service"
+    "scripts/daemon/consensus.service": "/lib/systemd/system/consensus.service"
 
   # scripts:
   #   preinstall: "scripts/preinstall.bash"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - 1.13.x
 
-go_import_path: github.com/Fantom-foundation/lachesis-base
+go_import_path: github.com/0xsoniclabs/consensus
 
 cache:
   directories:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Please check if what you want to add to `lachesis-base` list meets [quality standards](https://github.com/Fantom-foundation/lachesis-base/blob/master/CONTRIBUTING.md#quality-standard) before sending pull request.
+Please check if what you want to add to `consensus` list meets [quality standards](https://github.com/0xsoniclabs/consensus/blob/master/CONTRIBUTING.md#quality-standard) before sending pull request.
 
 **Please provide package links to:**
 
@@ -14,4 +14,4 @@ Please check if what you want to add to `lachesis-base` list meets [quality stan
 - [ ] I have added godoc link to the repo and to my pull request.
 - [ ] I have added coverage service link to the repo and to my pull request.
 - [ ] I have added goreportcard link to the repo and to my pull request.
-- [ ] I have read [Contribution guidelines](https://github.com/Fantom-foundation/lachesis-base/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/Fantom-foundation/lachesis-base/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/Fantom-foundation/lachesis-base/blob/master/CONTRIBUTING.md#quality-standard).
+- [ ] I have read [Contribution guidelines](https://github.com/0xsoniclabs/consensus/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/0xsoniclabs/consensus/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/0xsoniclabs/consensus/blob/master/CONTRIBUTING.md#quality-standard).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Lachesis base 
+# Sonic Consensus
 
 A base library defines interfaces and modules of aBFT Lachesis consensus protocol.
-Part of Fantom's Consensus-as-a-Service for distributed applications.
+Part of Sonic's Consensus-as-a-Service for distributed applications.
 
 ## Build Details
 

--- a/abft/apply_genesis.go
+++ b/abft/apply_genesis.go
@@ -3,8 +3,8 @@ package abft
 import (
 	"fmt"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 // Genesis stores genesis state

--- a/abft/bootstrap.go
+++ b/abft/bootstrap.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Fantom-foundation/lachesis-base/abft/election"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/abft/election"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 const (

--- a/abft/calc_frame_test.go
+++ b/abft/calc_frame_test.go
@@ -3,10 +3,10 @@ package abft
 import (
 	"testing"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 func TestCalFrameIdx_10000(t *testing.T) {

--- a/abft/check_against_db.go
+++ b/abft/check_against_db.go
@@ -5,11 +5,11 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/lachesis"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/lachesis"
 )
 
 func CheckEpochAgainstDB(conn *sql.DB, epoch idx.Epoch) error {

--- a/abft/config.go
+++ b/abft/config.go
@@ -1,6 +1,6 @@
 package abft
 
-import "github.com/Fantom-foundation/lachesis-base/utils/cachescale"
+import "github.com/0xsoniclabs/consensus/utils/cachescale"
 
 type Config struct {
 	// Suppresses the frame missmatch panic - used only for importing older historical event files, disabled by default

--- a/abft/dagidx/dag_indexer.go
+++ b/abft/dagidx/dag_indexer.go
@@ -1,8 +1,8 @@
 package dagidx
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 type Seq interface {

--- a/abft/election/debug.go
+++ b/abft/election/debug.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/0xsoniclabs/consensus/hash"
 )
 
 // DebugStateHash may be used in tests to match election state

--- a/abft/election/election.go
+++ b/abft/election/election.go
@@ -1,9 +1,9 @@
 package election
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 type (

--- a/abft/election/election_math.go
+++ b/abft/election/election_math.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 // ProcessRoot calculates Atropos votes only for the new root.

--- a/abft/election/election_test.go
+++ b/abft/election/election_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/utils"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/utils"
 )
 
 type fakeEdge struct {

--- a/abft/emission_sim_test.go
+++ b/abft/emission_sim_test.go
@@ -12,12 +12,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/emitter/ancestor"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/emitter/ancestor"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 type Results struct {
@@ -61,7 +61,7 @@ func Benchmark_Emission(b *testing.B) {
 	for i, _ := range weights {
 		// uncomment one of the below options for valiator stake distribution
 		weights[i] = pos.Weight(1)                               //for equal stake
-		weights[i] = pos.Weight(sampleDist(stakeRNG, stakeDist)) // for non-equal stake sample from Fantom main net validator stake distribution
+		weights[i] = pos.Weight(sampleDist(stakeRNG, stakeDist)) // for non-equal stake sample from Sonic main net validator stake distribution
 	}
 	sort.Slice(weights, func(i, j int) bool { return weights[i] > weights[j] }) // sort weights in order
 	QIParentCount := 12                                                         // maximum number of parents selected by FC indexer
@@ -83,7 +83,7 @@ func Benchmark_Emission(b *testing.B) {
 	// // seed = time.Now().UnixNano() //use this for a different seed each time the simulator runs
 	// maxLatency := latency.initialise(numNodes, seed)
 
-	// Latencies between validators are drawn from a dataset of latencies observed by one Fantom main net validator. Note all pairs of validators will use the same distribution
+	// Latencies between validators are drawn from a dataset of latencies observed by one Sonic main net validator. Note all pairs of validators will use the same distribution
 	// var latency mainNetLatency
 	// maxLatency := latency.initialise()
 

--- a/abft/event_processing.go
+++ b/abft/event_processing.go
@@ -3,9 +3,9 @@ package abft
 import (
 	"github.com/pkg/errors"
 
-	"github.com/Fantom-foundation/lachesis-base/abft/election"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/abft/election"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 var (

--- a/abft/event_processing_root_test.go
+++ b/abft/event_processing_root_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 func TestLachesisClassicRoots(t *testing.T) {

--- a/abft/event_processing_test.go
+++ b/abft/event_processing_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/lachesis"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/lachesis"
 )
 
 const (

--- a/abft/events_source.go
+++ b/abft/events_source.go
@@ -1,8 +1,8 @@
 package abft
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
 )
 
 // EventSource is a callback for getting events from an external storage.

--- a/abft/events_source_test.go
+++ b/abft/events_source_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
 )
 
 /*

--- a/abft/frame_decide.go
+++ b/abft/frame_decide.go
@@ -1,9 +1,9 @@
 package abft
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 // onFrameDecided moves LastDecidedFrameN to frame.

--- a/abft/frame_decide_test.go
+++ b/abft/frame_decide_test.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/lachesis"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/lachesis"
 )
 
 func TestConfirmBlocks_1(t *testing.T) {

--- a/abft/indexed_lachesis.go
+++ b/abft/indexed_lachesis.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/Fantom-foundation/lachesis-base/abft/dagidx"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
-	"github.com/Fantom-foundation/lachesis-base/lachesis"
+	"github.com/0xsoniclabs/consensus/abft/dagidx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/flushable"
+	"github.com/0xsoniclabs/consensus/lachesis"
 )
 
 var _ lachesis.Consensus = (*IndexedLachesis)(nil)

--- a/abft/lachesis.go
+++ b/abft/lachesis.go
@@ -1,12 +1,12 @@
 package abft
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/abft/dagidx"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/lachesis"
+	"github.com/0xsoniclabs/consensus/abft/dagidx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/lachesis"
 )
 
 var _ lachesis.Consensus = (*Lachesis)(nil)

--- a/abft/orderer.go
+++ b/abft/orderer.go
@@ -1,11 +1,11 @@
 package abft
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/abft/dagidx"
-	"github.com/Fantom-foundation/lachesis-base/abft/election"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/abft/dagidx"
+	"github.com/0xsoniclabs/consensus/abft/election"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 type OrdererCallbacks struct {

--- a/abft/restart_test.go
+++ b/abft/restart_test.go
@@ -8,15 +8,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
-	"github.com/Fantom-foundation/lachesis-base/lachesis"
-	"github.com/Fantom-foundation/lachesis-base/utils/adapters"
-	"github.com/Fantom-foundation/lachesis-base/vecfc"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/memorydb"
+	"github.com/0xsoniclabs/consensus/lachesis"
+	"github.com/0xsoniclabs/consensus/utils/adapters"
+	"github.com/0xsoniclabs/consensus/vecfc"
 )
 
 func TestRestart_1(t *testing.T) {

--- a/abft/store.go
+++ b/abft/store.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/rlp"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
-	"github.com/Fantom-foundation/lachesis-base/utils/simplewlru"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/memorydb"
+	"github.com/0xsoniclabs/consensus/kvdb/table"
+	"github.com/0xsoniclabs/consensus/utils/simplewlru"
 )
 
 // Store is a abft persistent storage working over parent key-value database.

--- a/abft/store_epoch_state.go
+++ b/abft/store_epoch_state.go
@@ -1,8 +1,8 @@
 package abft
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 const esKey = "e"

--- a/abft/store_event_confirmed.go
+++ b/abft/store_event_confirmed.go
@@ -1,8 +1,8 @@
 package abft
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 // SetEventConfirmedOn stores confirmed event hash.

--- a/abft/store_last_decided_state.go
+++ b/abft/store_last_decided_state.go
@@ -1,7 +1,7 @@
 package abft
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 const dsKey = "d"

--- a/abft/store_roots.go
+++ b/abft/store_roots.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/Fantom-foundation/lachesis-base/abft/election"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/abft/election"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 func rootRecordKey(r *election.RootAndSlot) []byte {

--- a/abft/test_utils.go
+++ b/abft/test_utils.go
@@ -3,15 +3,15 @@ package abft
 import (
 	"math/rand"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
-	"github.com/Fantom-foundation/lachesis-base/lachesis"
-	"github.com/Fantom-foundation/lachesis-base/utils/adapters"
-	"github.com/Fantom-foundation/lachesis-base/vecfc"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/memorydb"
+	"github.com/0xsoniclabs/consensus/lachesis"
+	"github.com/0xsoniclabs/consensus/utils/adapters"
+	"github.com/0xsoniclabs/consensus/vecfc"
 )
 
 type dbEvent struct {

--- a/abft/traversal.go
+++ b/abft/traversal.go
@@ -3,8 +3,8 @@ package abft
 import (
 	"errors"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
 )
 
 type eventFilterFn func(event dag.Event) bool

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ image: Visual Studio 2017
 
 build: off
 
-clone_folder: c:\gopath\src\github.com\Fantom-foundation\lachesis-base
+clone_folder: c:\gopath\src\github.com\0xsoniclabs\consensus
 
 environment:
   PATH: C:\gopath\bin;C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;C:\PROGRA~1\Git\bin;C:\PROGRA~1\Git\usr\bin\;C:\ProgramData\chocolatey\bin;$(PATH)

--- a/cmd/dbchecker/main.go
+++ b/cmd/dbchecker/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Fantom-foundation/lachesis-base/abft"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/abft"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/urfave/cli/v2"
 )
@@ -31,7 +31,7 @@ func main() {
 	app := &cli.App{
 		Name:        "Event DB Checker",
 		Description: "Consensus regression testing tool",
-		Copyright:   "(c) 2024 Fantom Foundation",
+		Copyright:   "(c) 2025 Sonic Labs",
 		Flags:       []cli.Flag{&DbPathFlag, &EpochMinFlag, &EpochMaxFlag},
 		Action:      run,
 	}

--- a/common/bytes_test.go
+++ b/common/bytes_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
-	"github.com/Fantom-foundation/lachesis-base/common/littleendian"
+	"github.com/0xsoniclabs/consensus/common/bigendian"
+	"github.com/0xsoniclabs/consensus/common/littleendian"
 )
 
 func Test_IntToBytes(t *testing.T) {

--- a/emitter/ancestor/fc_indexer.go
+++ b/emitter/ancestor/fc_indexer.go
@@ -1,10 +1,10 @@
 package ancestor
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 const (

--- a/emitter/ancestor/payload_indexer.go
+++ b/emitter/ancestor/payload_indexer.go
@@ -1,9 +1,9 @@
 package ancestor
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/utils/wlru"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/utils/wlru"
 )
 
 type PayloadIndexer struct {

--- a/emitter/ancestor/quorum_indexer.go
+++ b/emitter/ancestor/quorum_indexer.go
@@ -4,12 +4,12 @@ import (
 	"math"
 	"sort"
 
-	"github.com/Fantom-foundation/lachesis-base/abft/dagidx"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/utils/wmedian"
+	"github.com/0xsoniclabs/consensus/abft/dagidx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/utils/wmedian"
 )
 
 type DagIndexQ interface {

--- a/emitter/ancestor/rand.go
+++ b/emitter/ancestor/rand.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/0xsoniclabs/consensus/hash"
 )
 
 /*

--- a/emitter/ancestor/search.go
+++ b/emitter/ancestor/search.go
@@ -1,7 +1,7 @@
 package ancestor
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/0xsoniclabs/consensus/hash"
 )
 
 // SearchStrategy defines a criteria used to estimate the "best" subset of parents to emit event with.

--- a/emitter/ancestor/weighted.go
+++ b/emitter/ancestor/weighted.go
@@ -1,7 +1,7 @@
 package ancestor
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/0xsoniclabs/consensus/hash"
 )
 
 type Metric uint64

--- a/eventcheck/all.go
+++ b/eventcheck/all.go
@@ -1,10 +1,10 @@
 package eventcheck
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/eventcheck/basiccheck"
-	"github.com/Fantom-foundation/lachesis-base/eventcheck/epochcheck"
-	"github.com/Fantom-foundation/lachesis-base/eventcheck/parentscheck"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/0xsoniclabs/consensus/eventcheck/basiccheck"
+	"github.com/0xsoniclabs/consensus/eventcheck/epochcheck"
+	"github.com/0xsoniclabs/consensus/eventcheck/parentscheck"
+	"github.com/0xsoniclabs/consensus/inter/dag"
 )
 
 // Checkers is collection of all the checkers

--- a/eventcheck/all_test.go
+++ b/eventcheck/all_test.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/eventcheck/basiccheck"
-	"github.com/Fantom-foundation/lachesis-base/eventcheck/epochcheck"
-	"github.com/Fantom-foundation/lachesis-base/eventcheck/parentscheck"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/eventcheck/basiccheck"
+	"github.com/0xsoniclabs/consensus/eventcheck/epochcheck"
+	"github.com/0xsoniclabs/consensus/eventcheck/parentscheck"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 type testReader struct{}

--- a/eventcheck/basiccheck/basic_check.go
+++ b/eventcheck/basiccheck/basic_check.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"math"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag"
 )
 
 var (

--- a/eventcheck/epochcheck/epoch_check.go
+++ b/eventcheck/epochcheck/epoch_check.go
@@ -3,9 +3,9 @@ package epochcheck
 import (
 	"errors"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 var (

--- a/eventcheck/parentscheck/parents_check.go
+++ b/eventcheck/parentscheck/parents_check.go
@@ -3,8 +3,8 @@ package parentscheck
 import (
 	"errors"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Fantom-foundation/lachesis-base
+module github.com/0xsoniclabs/consensus
 
 go 1.21
 

--- a/gossip/basestream/basestreamseeder/seeder.go
+++ b/gossip/basestream/basestreamseeder/seeder.go
@@ -6,8 +6,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/gossip/basestream"
-	"github.com/Fantom-foundation/lachesis-base/utils/workers"
+	"github.com/0xsoniclabs/consensus/gossip/basestream"
+	"github.com/0xsoniclabs/consensus/utils/workers"
 )
 
 var (

--- a/gossip/basestream/basestreamseeder/seeder_test.go
+++ b/gossip/basestream/basestreamseeder/seeder_test.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/Fantom-foundation/lachesis-base/gossip/basestream"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/gossip/basestream"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 func defaultConfig() Config {

--- a/gossip/basestream/basestreamseeder/types_test.go
+++ b/gossip/basestream/basestreamseeder/types_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/Fantom-foundation/lachesis-base/gossip/basestream"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/0xsoniclabs/consensus/gossip/basestream"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
 )
 
 type testLocator struct {

--- a/gossip/dagordering/event_buffer.go
+++ b/gossip/dagordering/event_buffer.go
@@ -4,11 +4,11 @@ import (
 	"math"
 	"sync"
 
-	"github.com/Fantom-foundation/lachesis-base/eventcheck"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/utils/wlru"
+	"github.com/0xsoniclabs/consensus/eventcheck"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/utils/wlru"
 )
 
 type (

--- a/gossip/dagordering/ordering_test.go
+++ b/gossip/dagordering/ordering_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 func TestEventsBuffer(t *testing.T) {

--- a/gossip/dagprocessor/config.go
+++ b/gossip/dagprocessor/config.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/utils/cachescale"
 )
 
 type Config struct {

--- a/gossip/dagprocessor/processor.go
+++ b/gossip/dagprocessor/processor.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/Fantom-foundation/lachesis-base/eventcheck"
-	"github.com/Fantom-foundation/lachesis-base/gossip/dagordering"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/utils/datasemaphore"
-	"github.com/Fantom-foundation/lachesis-base/utils/workers"
+	"github.com/0xsoniclabs/consensus/eventcheck"
+	"github.com/0xsoniclabs/consensus/gossip/dagordering"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/utils/datasemaphore"
+	"github.com/0xsoniclabs/consensus/utils/workers"
 )
 
 var (

--- a/gossip/dagprocessor/processor_test.go
+++ b/gossip/dagprocessor/processor_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
-	"github.com/Fantom-foundation/lachesis-base/utils/datasemaphore"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/utils/cachescale"
+	"github.com/0xsoniclabs/consensus/utils/datasemaphore"
 )
 
 func TestProcessor(t *testing.T) {

--- a/gossip/itemsfetcher/config.go
+++ b/gossip/itemsfetcher/config.go
@@ -3,7 +3,7 @@ package itemsfetcher
 import (
 	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
+	"github.com/0xsoniclabs/consensus/utils/cachescale"
 )
 
 type Config struct {

--- a/gossip/itemsfetcher/fetcher.go
+++ b/gossip/itemsfetcher/fetcher.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/utils/wlru"
-	"github.com/Fantom-foundation/lachesis-base/utils/workers"
+	"github.com/0xsoniclabs/consensus/utils/wlru"
+	"github.com/0xsoniclabs/consensus/utils/workers"
 )
 
 /*

--- a/hash/event_hash.go
+++ b/hash/event_hash.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/common/bigendian"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 type (

--- a/hash/log.go
+++ b/hash/log.go
@@ -3,7 +3,7 @@ package hash
 import (
 	"sync"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 var (

--- a/inter/dag/event.go
+++ b/inter/dag/event.go
@@ -3,8 +3,8 @@ package dag
 import (
 	"fmt"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 type Event interface {

--- a/inter/dag/events.go
+++ b/inter/dag/events.go
@@ -3,8 +3,8 @@ package dag
 import (
 	"strings"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 // Events is a ordered slice of events.

--- a/inter/dag/metric.go
+++ b/inter/dag/metric.go
@@ -3,7 +3,7 @@ package dag
 import (
 	"fmt"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 type Metric struct {

--- a/inter/dag/tdag/ascii_scheme.go
+++ b/inter/dag/tdag/ascii_scheme.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 type ForEachEvent struct {

--- a/inter/dag/tdag/ascii_scheme_test.go
+++ b/inter/dag/tdag/ascii_scheme_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/utils"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/utils"
 )
 
 func TestASCIIschemeToDAG(t *testing.T) {

--- a/inter/dag/tdag/event.go
+++ b/inter/dag/tdag/event.go
@@ -1,8 +1,8 @@
 package tdag
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
 )
 
 type TestEvent struct {

--- a/inter/dag/tdag/events.go
+++ b/inter/dag/tdag/events.go
@@ -3,8 +3,8 @@ package tdag
 import (
 	"strings"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
 )
 
 // TestEvents is a ordered slice of events.

--- a/inter/dag/tdag/events_test.go
+++ b/inter/dag/tdag/events_test.go
@@ -4,8 +4,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
 )
 
 func TestEventsByParents(t *testing.T) {

--- a/inter/dag/tdag/serialization.go
+++ b/inter/dag/tdag/serialization.go
@@ -3,8 +3,8 @@ package tdag
 import (
 	"github.com/ethereum/go-ethereum/rlp"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 type TestEventMarshaling struct {

--- a/inter/dag/tdag/test_common.go
+++ b/inter/dag/tdag/test_common.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 // GenNodes generates nodes.

--- a/inter/idx/index.go
+++ b/inter/idx/index.go
@@ -1,7 +1,7 @@
 package idx
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
+	"github.com/0xsoniclabs/consensus/common/bigendian"
 )
 
 type (

--- a/inter/idx/internal.go
+++ b/inter/idx/internal.go
@@ -1,7 +1,7 @@
 package idx
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
+	"github.com/0xsoniclabs/consensus/common/bigendian"
 )
 
 type (

--- a/inter/pos/sort.go
+++ b/inter/pos/sort.go
@@ -1,7 +1,7 @@
 package pos
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 type (

--- a/inter/pos/stake.go
+++ b/inter/pos/stake.go
@@ -1,7 +1,7 @@
 package pos
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 type (

--- a/inter/pos/stake_bigint.go
+++ b/inter/pos/stake_bigint.go
@@ -3,7 +3,7 @@ package pos
 import (
 	"math/big"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 // ValidatorsBuilderBig is a helper to create Validators object out of bigint numbers

--- a/inter/pos/validators.go
+++ b/inter/pos/validators.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/rlp"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 type (

--- a/inter/pos/validators_test.go
+++ b/inter/pos/validators_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 func TestNewValidators(t *testing.T) {

--- a/kvdb/batched/batched.go
+++ b/kvdb/batched/batched.go
@@ -1,6 +1,6 @@
 package batched
 
-import "github.com/Fantom-foundation/lachesis-base/kvdb"
+import "github.com/0xsoniclabs/consensus/kvdb"
 
 // Store is a wrapper which translates every Put/Delete op into a batch
 type Store struct {

--- a/kvdb/cachedproducer/producer.go
+++ b/kvdb/cachedproducer/producer.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 type cacheState struct {

--- a/kvdb/cachedproducer/store.go
+++ b/kvdb/cachedproducer/store.go
@@ -1,6 +1,6 @@
 package cachedproducer
 
-import "github.com/Fantom-foundation/lachesis-base/kvdb"
+import "github.com/0xsoniclabs/consensus/kvdb"
 
 type StoreWithFn struct {
 	kvdb.Store

--- a/kvdb/devnulldb/devnulldb.go
+++ b/kvdb/devnulldb/devnulldb.go
@@ -1,7 +1,7 @@
 package devnulldb
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 // Database is an always empty database.

--- a/kvdb/fallible/fallible.go
+++ b/kvdb/fallible/fallible.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"sync/atomic"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 var (

--- a/kvdb/fallible/fallible_test.go
+++ b/kvdb/fallible/fallible_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/memorydb"
 )
 
 func TestFallible(t *testing.T) {

--- a/kvdb/flaggedproducer/producer.go
+++ b/kvdb/flaggedproducer/producer.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/flushable"
 )
 
 type Producer struct {

--- a/kvdb/flaggedproducer/store.go
+++ b/kvdb/flaggedproducer/store.go
@@ -3,8 +3,8 @@ package flaggedproducer
 import (
 	"sync/atomic"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/flushable"
 )
 
 type flaggedStore struct {

--- a/kvdb/flushable/flushable.go
+++ b/kvdb/flushable/flushable.go
@@ -8,7 +8,7 @@ import (
 	rbt "github.com/emirpasic/gods/trees/redblacktree"
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 var (

--- a/kvdb/flushable/flushable_parallel_test.go
+++ b/kvdb/flushable/flushable_parallel_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/leveldb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
+	"github.com/0xsoniclabs/consensus/common/bigendian"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/leveldb"
+	"github.com/0xsoniclabs/consensus/kvdb/table"
 )
 
 func TestFlushableParallel(t *testing.T) {

--- a/kvdb/flushable/flushable_test.go
+++ b/kvdb/flushable/flushable_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
-	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/leveldb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
+	"github.com/0xsoniclabs/consensus/common/bigendian"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/leveldb"
+	"github.com/0xsoniclabs/consensus/kvdb/table"
 )
 
 func TestFlushable(t *testing.T) {

--- a/kvdb/flushable/lazy_flushable.go
+++ b/kvdb/flushable/lazy_flushable.go
@@ -1,8 +1,8 @@
 package flushable
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/devnulldb"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/devnulldb"
 )
 
 // LazyFlushable is a Flushable with delayed DB producer

--- a/kvdb/flushable/synced_pool.go
+++ b/kvdb/flushable/synced_pool.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/status-im/keycard-go/hexutils"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/readonlystore"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/synced"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/readonlystore"
+	"github.com/0xsoniclabs/consensus/kvdb/synced"
 )
 
 var _ kvdb.FlushableDBProducer = (*SyncedPool)(nil)

--- a/kvdb/flushable/synced_pool_test.go
+++ b/kvdb/flushable/synced_pool_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
+	"github.com/0xsoniclabs/consensus/common/bigendian"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/table"
 )
 
 func TestSyncedPoolUnderlying(t *testing.T) {

--- a/kvdb/leveldb/leveldb.go
+++ b/kvdb/leveldb/leveldb.go
@@ -14,8 +14,8 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/utils/piecefunc"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/utils/piecefunc"
 )
 
 const (

--- a/kvdb/leveldb/producer.go
+++ b/kvdb/leveldb/producer.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 type Producer struct {

--- a/kvdb/memorydb/fake_fs.go
+++ b/kvdb/memorydb/fake_fs.go
@@ -4,8 +4,8 @@ import (
 	"math/rand"
 	"sync"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 type fakeFS struct {

--- a/kvdb/memorydb/memorydb.go
+++ b/kvdb/memorydb/memorydb.go
@@ -2,9 +2,9 @@
 package memorydb
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/devnulldb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/devnulldb"
+	"github.com/0xsoniclabs/consensus/kvdb/flushable"
 )
 
 // Database is an ephemeral key-value store. Apart from basic data storage

--- a/kvdb/memorydb/producer.go
+++ b/kvdb/memorydb/producer.go
@@ -1,7 +1,7 @@
 package memorydb
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 type Mod func(store kvdb.Store) kvdb.Store

--- a/kvdb/memorydb/synced_pool_test.go
+++ b/kvdb/memorydb/synced_pool_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
+	"github.com/0xsoniclabs/consensus/common/bigendian"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/flushable"
+	"github.com/0xsoniclabs/consensus/kvdb/table"
 )
 
 func TestSyncedPoolUnderlying(t *testing.T) {

--- a/kvdb/multidb/producer.go
+++ b/kvdb/multidb/producer.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
-	"github.com/Fantom-foundation/lachesis-base/utils/fmtfilter"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/table"
+	"github.com/0xsoniclabs/consensus/utils/fmtfilter"
 )
 
 type Producer struct {

--- a/kvdb/multidb/producer_test.go
+++ b/kvdb/multidb/producer_test.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
+	"github.com/0xsoniclabs/consensus/kvdb/flushable"
+	"github.com/0xsoniclabs/consensus/kvdb/memorydb"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/keycard-go/hexutils"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/kvdb/multidb/records.go
+++ b/kvdb/multidb/records.go
@@ -3,7 +3,7 @@ package multidb
 import (
 	"github.com/ethereum/go-ethereum/rlp"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 type TableRecord struct {

--- a/kvdb/multidb/store.go
+++ b/kvdb/multidb/store.go
@@ -1,6 +1,6 @@
 package multidb
 
-import "github.com/Fantom-foundation/lachesis-base/kvdb"
+import "github.com/0xsoniclabs/consensus/kvdb"
 
 type closableTable struct {
 	kvdb.Store

--- a/kvdb/nokeyiserr/wrapper.go
+++ b/kvdb/nokeyiserr/wrapper.go
@@ -3,7 +3,7 @@ package nokeyiserr
 import (
 	"errors"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 var (

--- a/kvdb/pebble/pebble.go
+++ b/kvdb/pebble/pebble.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/utils/piecefunc"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/utils/piecefunc"
 )
 
 // Database is a persistent key-value store. Apart from basic data storage

--- a/kvdb/pebble/producer.go
+++ b/kvdb/pebble/producer.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 type Producer struct {

--- a/kvdb/readonlystore/store.go
+++ b/kvdb/readonlystore/store.go
@@ -1,6 +1,6 @@
 package readonlystore
 
-import "github.com/Fantom-foundation/lachesis-base/kvdb"
+import "github.com/0xsoniclabs/consensus/kvdb"
 
 type Store struct {
 	kvdb.Store

--- a/kvdb/skiperrors/skiperrors.go
+++ b/kvdb/skiperrors/skiperrors.go
@@ -1,7 +1,7 @@
 package skiperrors
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 // wrapper is a kvdb.Store wrapper around any kvdb.Store.

--- a/kvdb/skiperrors/skiperrors_test.go
+++ b/kvdb/skiperrors/skiperrors_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
+	"github.com/0xsoniclabs/consensus/kvdb/memorydb"
+	"github.com/0xsoniclabs/consensus/kvdb/table"
 )
 
 func TestWrapper(t *testing.T) {

--- a/kvdb/skipkeys/producer.go
+++ b/kvdb/skipkeys/producer.go
@@ -1,7 +1,7 @@
 package skipkeys
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 func openDB(p kvdb.DBProducer, skipPrefix []byte, name string) (kvdb.Store, error) {

--- a/kvdb/skipkeys/store.go
+++ b/kvdb/skipkeys/store.go
@@ -3,7 +3,7 @@ package skipkeys
 import (
 	"bytes"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 type Store struct {

--- a/kvdb/synced/readonly.go
+++ b/kvdb/synced/readonly.go
@@ -3,7 +3,7 @@ package synced
 import (
 	"sync"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 // iteratedReader wrapper around any kvdb.IteratedReader.

--- a/kvdb/synced/store.go
+++ b/kvdb/synced/store.go
@@ -3,7 +3,7 @@ package synced
 import (
 	"sync"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 // store wrapper around any kvdb.Store.

--- a/kvdb/table/mock_test.go
+++ b/kvdb/table/mock_test.go
@@ -7,7 +7,7 @@ package table
 import (
 	reflect "reflect"
 
-	kvdb "github.com/Fantom-foundation/lachesis-base/kvdb"
+	kvdb "github.com/0xsoniclabs/consensus/kvdb"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/kvdb/table/readonly.go
+++ b/kvdb/table/readonly.go
@@ -1,7 +1,7 @@
 package table
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 type IteratedReader struct {

--- a/kvdb/table/reflect.go
+++ b/kvdb/table/reflect.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 // MigrateTables sets target fields to database tables.

--- a/kvdb/table/reflect_test.go
+++ b/kvdb/table/reflect_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 type testTables struct {

--- a/kvdb/table/table.go
+++ b/kvdb/table/table.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 // Table wraper the underling DB, so all the table's data is stored with a prefix in underling DB

--- a/kvdb/table/table_test.go
+++ b/kvdb/table/table_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/leveldb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/flushable"
+	"github.com/0xsoniclabs/consensus/kvdb/leveldb"
+	"github.com/0xsoniclabs/consensus/kvdb/memorydb"
 )
 
 func tempLevelDB(name string) *leveldb.Database {

--- a/lachesis/block.go
+++ b/lachesis/block.go
@@ -1,7 +1,7 @@
 package lachesis
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/0xsoniclabs/consensus/hash"
 )
 
 // Block is a part of an ordered chain of batches of events.

--- a/lachesis/cheaters_list.go
+++ b/lachesis/cheaters_list.go
@@ -3,7 +3,7 @@ package lachesis
 import (
 	"github.com/ethereum/go-ethereum/rlp"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 // Cheaters is a slice type for storing cheaters list.

--- a/lachesis/consensus.go
+++ b/lachesis/consensus.go
@@ -1,9 +1,9 @@
 package lachesis
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 // Consensus is a consensus interface.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=Fantom-foundation_lachesis-base
-sonar.projectName=lachesis-base
+sonar.projectKey=0xsoniclabs-consensus
+sonar.projectName=consensus
  
 sonar.sources=.
 sonar.exclusions=**/*_test.go,**/vendor/**

--- a/tests/main.go
+++ b/tests/main.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/Fantom-foundation/lachesis-base/abft"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
-	"github.com/Fantom-foundation/lachesis-base/utils/adapters"
-	"github.com/Fantom-foundation/lachesis-base/vecfc"
+	"github.com/0xsoniclabs/consensus/abft"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/memorydb"
+	"github.com/0xsoniclabs/consensus/utils/adapters"
+	"github.com/0xsoniclabs/consensus/vecfc"
 )
 
 func main() {

--- a/utils/adapters/vector_to_dagidx.go
+++ b/utils/adapters/vector_to_dagidx.go
@@ -1,10 +1,10 @@
 package adapters
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/abft/dagidx"
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/vecfc"
+	"github.com/0xsoniclabs/consensus/abft/dagidx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/vecfc"
 )
 
 type VectorSeqToDagIndexSeq struct {

--- a/utils/cachescale/interface.go
+++ b/utils/cachescale/interface.go
@@ -1,7 +1,7 @@
 package cachescale
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 type Func interface {

--- a/utils/cachescale/ratio.go
+++ b/utils/cachescale/ratio.go
@@ -1,7 +1,7 @@
 package cachescale
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 // Ratio alters the cache sizes proportionally to a ratio

--- a/utils/datasemaphore/semaphore.go
+++ b/utils/datasemaphore/semaphore.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag"
 )
 
 type DataSemaphore struct {

--- a/utils/util.go
+++ b/utils/util.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"fmt"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 // NameOf returns human readable string representation.

--- a/utils/wlru/wlru.go
+++ b/utils/wlru/wlru.go
@@ -3,7 +3,7 @@ package wlru
 import (
 	"sync"
 
-	"github.com/Fantom-foundation/lachesis-base/utils/simplewlru"
+	"github.com/0xsoniclabs/consensus/utils/simplewlru"
 )
 
 // Cache is a thread-safe fixed size LRU cache.

--- a/utils/wmedian/median.go
+++ b/utils/wmedian/median.go
@@ -1,7 +1,7 @@
 package wmedian
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 type WeightedValue interface {

--- a/vecengine/branches_info.go
+++ b/vecengine/branches_info.go
@@ -1,8 +1,8 @@
 package vecengine
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 // BranchesInfo contains information about global branches of each validator

--- a/vecengine/index.go
+++ b/vecengine/index.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/table"
 )
 
 type Callbacks struct {

--- a/vecengine/store_branches_info.go
+++ b/vecengine/store_branches_info.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/rlp"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 func (vi *Engine) setRlp(table kvdb.Store, key []byte, val interface{}) {

--- a/vecengine/traversal.go
+++ b/vecengine/traversal.go
@@ -3,8 +3,8 @@ package vecengine
 import (
 	"errors"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
 )
 
 // DfsSubgraph iterates all the event which are observed by head, and accepted by a filter

--- a/vecengine/vecflushable/backed_map.go
+++ b/vecengine/vecflushable/backed_map.go
@@ -3,7 +3,7 @@ package vecflushable
 import (
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 // TestSizeLimit is used as the limit in unit-test of packages that use vecflushable

--- a/vecengine/vecflushable/vecflushable.go
+++ b/vecengine/vecflushable/vecflushable.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 var (

--- a/vecengine/vecflushable/vecflushable_test.go
+++ b/vecengine/vecflushable/vecflushable_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
-	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/devnulldb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/leveldb"
+	"github.com/0xsoniclabs/consensus/common/bigendian"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/devnulldb"
+	"github.com/0xsoniclabs/consensus/kvdb/leveldb"
 )
 
 // TestVecflushableNoBackup tests normal operation of vecflushable, before and after

--- a/vecengine/vector.go
+++ b/vecengine/vector.go
@@ -1,8 +1,8 @@
 package vecengine
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 type LowestAfterI interface {

--- a/vecfc/forkless_cause.go
+++ b/vecfc/forkless_cause.go
@@ -3,9 +3,9 @@ package vecfc
 import (
 	"fmt"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
 type kv struct {

--- a/vecfc/forkless_cause_test.go
+++ b/vecfc/forkless_cause_test.go
@@ -9,15 +9,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
-	"github.com/Fantom-foundation/lachesis-base/vecengine/vecflushable"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/flushable"
+	"github.com/0xsoniclabs/consensus/kvdb/memorydb"
+	"github.com/0xsoniclabs/consensus/vecengine/vecflushable"
 )
 
 func tCrit(err error) { panic(err) }

--- a/vecfc/index.go
+++ b/vecfc/index.go
@@ -1,15 +1,15 @@
 package vecfc
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
-	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
-	"github.com/Fantom-foundation/lachesis-base/utils/simplewlru"
-	"github.com/Fantom-foundation/lachesis-base/vecengine"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/table"
+	"github.com/0xsoniclabs/consensus/utils/cachescale"
+	"github.com/0xsoniclabs/consensus/utils/simplewlru"
+	"github.com/0xsoniclabs/consensus/vecengine"
 )
 
 // IndexCacheConfig - config for cache sizes of Engine

--- a/vecfc/index_test.go
+++ b/vecfc/index_test.go
@@ -7,15 +7,15 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
-	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/leveldb"
-	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
-	"github.com/Fantom-foundation/lachesis-base/vecengine/vecflushable"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+	"github.com/0xsoniclabs/consensus/kvdb"
+	"github.com/0xsoniclabs/consensus/kvdb/flushable"
+	"github.com/0xsoniclabs/consensus/kvdb/leveldb"
+	"github.com/0xsoniclabs/consensus/kvdb/memorydb"
+	"github.com/0xsoniclabs/consensus/vecengine/vecflushable"
 )
 
 func BenchmarkIndex_Add_MemoryDB(b *testing.B) {

--- a/vecfc/store_vectors.go
+++ b/vecfc/store_vectors.go
@@ -1,8 +1,8 @@
 package vecfc
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/0xsoniclabs/consensus/hash"
+	"github.com/0xsoniclabs/consensus/kvdb"
 )
 
 func (vi *Index) getBytes(table kvdb.Store, id hash.Event) []byte {

--- a/vecfc/vector.go
+++ b/vecfc/vector.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"math"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 /*

--- a/vecfc/vector_ops.go
+++ b/vecfc/vector_ops.go
@@ -1,9 +1,9 @@
 package vecfc
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/inter/dag"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/vecengine"
+	"github.com/0xsoniclabs/consensus/inter/dag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/vecengine"
 )
 
 func (b *LowestAfterSeq) InitWithEvent(i idx.Validator, e dag.Event) {


### PR DESCRIPTION
This PR is concerned with ticket https://github.com/0xsoniclabs/sonic-consensus/issues/17

We would like to replace all Fantom module names such as `github.com/Fantom-foundation/lachesis-base`, which are to be deprecated, with `github.com/0xsoniclabs/sonic-consensus` in this repository and ensure that dependencies to `github.com/Fantom-foundation/lachesis-base` in the client and other repositories will be able to migrate smoothly as well. 

---

TODO:

- [x] Decide on if `github.com/0xsoniclabs/sonic-consensus` is to be used as opposed to `github.com/0xsoniclabs/consensus` (which may also require this repository to change from `sonic-consensus` to `consensus` - prefer consensus
- [x] Verify if `.golangci.yml`, `.travis.yml`, `appveyor.yml`, `.goreleaser.yml` changes are compatible - all four should be changed
- [x] Verify if it is okay for `sonar-project.properties` values to change for project key and project name to `sonar.projectKey=0xsoniclabs-consensus' & `sonar.projectName=sonic-consensus` - change it
- [x] Confirm changes are compatible with Sonic client
- [x] Verify if `CODEOWNERS`  - adjust code owners
- [ ] Create the first tagged release (conforming to semver) after merging PR 
- [ ] Raise a pull request in `sonic` repository to reference `consensus`

---

Verification (`consensus` repo):

![image](https://github.com/user-attachments/assets/0e242ad8-87f9-41f4-a5d3-95943660f19e)


Verification (`sonic` repo):

![image](https://github.com/user-attachments/assets/dbfe8dbb-fdbf-4cc7-9d94-2d3dd9b7a505)

The test in the `sonic` repo has been conducted by:
- modifying the `sonic` `go.mod` file to remove `lachesis-base` from the `require statement` at the top
- modifying the replace directive from `replace github.com/Fantom-foundation/lachesis-base => github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20241018103023-632a59c242f5` to `replace github.com/0xsoniclabs/consensus => /home/ak/Desktop/Sonic/consensus` (resolves to local version of `sonic-consensus` repo) 
- modifying all references in the `sonic` repo's go files from `github.com/Fantom-foundation/lachesis-base` to `github.com/0xsoniclabs/consensus`
- running `go mod tidy`
- running `make all`

