### PR TITLE
Move Emission Test to emitter

### DIFF
--- a/abft/check_against_db.go
+++ b/abft/check_against_db.go
@@ -96,7 +96,7 @@ func ingestEvent(testLachesis *CoreLachesis, eventStore *EventStore, event *dbEv
 // event lifecycle in local computation intensive consensus components - DAG indexing, frame calculation, election
 // Conditions and order in which the components are invoked are identical to production Consensus behaviour
 func processLocalEvent(testLachesis *CoreLachesis, event *tdag.TestEvent, targetFrame idx.Frame) error {
-	if err := testLachesis.dagIndexer.Add(event); err != nil {
+	if err := testLachesis.DagIndexer.Add(event); err != nil {
 		return fmt.Errorf("error wihile indexing event: [validator: %d, seq: %d], err: %v", event.Creator(), event.Seq(), err)
 	}
 	if err := testLachesis.Lachesis.Build(event); err != nil {

--- a/abft/event_processing.go
+++ b/abft/event_processing.go
@@ -142,10 +142,10 @@ func (p *Orderer) calcFrameIdx(e dag.Event) (selfParentFrame, frame idx.Frame) {
 	if e.SelfParent() == nil {
 		return 0, 1
 	}
-	selfParentFrame = p.input.GetEvent(*e.SelfParent()).Frame()
+	selfParentFrame = p.Input.GetEvent(*e.SelfParent()).Frame()
 	frame = selfParentFrame
 	for _, parent := range e.Parents() {
-		frame = max(frame, p.input.GetEvent(parent).Frame())
+		frame = max(frame, p.Input.GetEvent(parent).Frame())
 	}
 
 	if p.forklessCausedByQuorumOn(e, frame) {
@@ -158,5 +158,5 @@ func (p *Orderer) getSelfParentFrame(e dag.Event) idx.Frame {
 	if e.SelfParent() == nil {
 		return 0
 	}
-	return p.input.GetEvent(*e.SelfParent()).Frame()
+	return p.Input.GetEvent(*e.SelfParent()).Frame()
 }

--- a/abft/orderer.go
+++ b/abft/orderer.go
@@ -24,7 +24,7 @@ type Orderer struct {
 	config Config
 	crit   func(error)
 	store  *Store
-	input  EventSource
+	Input  EventSource
 
 	election *election.Election
 	dagIndex OrdererDagIndex
@@ -39,7 +39,7 @@ func NewOrderer(store *Store, input EventSource, dagIndex OrdererDagIndex, crit 
 	p := &Orderer{
 		config:   config,
 		store:    store,
-		input:    input,
+		Input:    input,
 		crit:     crit,
 		dagIndex: dagIndex,
 	}

--- a/abft/restart_test.go
+++ b/abft/restart_test.go
@@ -183,7 +183,7 @@ func testRestartAndReset(t *testing.T, weights []pos.Weight, mutateWeights bool,
 				return memorydb.New()
 			}
 
-			restored := NewIndexedLachesis(store, prev.input, &adapters.VectorToDagIndexer{Index: vecfc.NewIndex(prev.crit, vecfc.LiteConfig())}, prev.crit, prev.config)
+			restored := NewIndexedLachesis(store, prev.Input, &adapters.VectorToDagIndexer{Index: vecfc.NewIndex(prev.crit, vecfc.LiteConfig())}, prev.crit, prev.config)
 			assertar.NoError(restored.Bootstrap(prev.callback))
 
 			lchs[RESTORED].IndexedLachesis = restored

--- a/abft/traversal.go
+++ b/abft/traversal.go
@@ -17,7 +17,7 @@ func (p *Orderer) dfsSubgraph(head hash.Event, filter eventFilterFn) error {
 	for pwalk := &head; pwalk != nil; pwalk = stack.Pop() {
 		walk := *pwalk
 
-		event := p.input.GetEvent(walk)
+		event := p.Input.GetEvent(walk)
 		if event == nil {
 			return errors.New("event not found " + walk.String())
 		}


### PR DESCRIPTION
The purpose of this PR is to migrate the `emission_sim_test.go`, which previously sat in the `abft` package, into the `emitter` package. This is required because the test priorly had dependencies on the `emitter`, and if the `emitter` were to move to the `sonic` repository, this would mean that the `consensus` repository would require the `sonic` repository.

- [x] - Moved `emission_sim_test.go` into the `emitter` package to decouple `abft` and `emitter`
- [x] - Changed the export visibility of associated types as required in `abft` and everywhere they were referenced in order for the test to work in the `emitter` package
- [x]  - Verified that the `emission_sim_test.go` `Benchmark_Emission` test runs as expected when inside the `emitter` (to be updated, it worked prior to rebasing to the latest two commits on `main`)

---

![image](https://github.com/user-attachments/assets/b29505be-cadf-4da5-89a8-c107882736b3)
