### PR TITLE
Skip the SIMD-based function when slices are empty

### DIFF
--- a/abft/election/vector_ops.go
+++ b/abft/election/vector_ops.go
@@ -3,6 +3,9 @@ package election
 import "github.com/kelindar/simd"
 
 func addInt32Vecs(dst []int32, src1 []int32, src2 []int32) {
+	if len(src1) == 0 {
+		return
+	}
 	simd.AddInt32s(dst, src1, src2)
 }
 


### PR DESCRIPTION
AVX2 instruction under the hood, when supported, relies on forwarded in-memory arrays not being empty.