### PR TITLE
feat: fmtfilter tests

### DIFF
--- a/utils/fmtfilter/fmt.go
+++ b/utils/fmtfilter/fmt.go
@@ -17,31 +17,42 @@ import (
 	"unicode"
 )
 
+// parseScanfOps extracts the format specifiers (%d, %s) from a template string.
+// For example, parseScanfOps("Hello %d World %s") returns "%d%s", nil.
 func parseScanfOps(template string) (string, error) {
-	readOp := false
-	ops := ""
+	readOp := false // Flag to indicate if we're currently expecting a format specifier after a '%'
+	ops := ""       // String to accumulate the format specifiers
 	for i, ch := range template {
-		if readOp {
+		if readOp { // If the previous character was a '%'
 			if ch == 'd' {
 				ops += "%d"
 			} else if ch == 's' {
 				ops += "%s"
 			} else if ch == '%' {
+				// Handle escaped percent signs (%%) - do nothing, just consume the second '%'
 			} else if !unicode.IsLetter(ch) {
+				// Allow non-letter characters immediately after the % (e.g. %10d)
 				continue
 			} else {
+				// Invalid format specifier
 				return "", fmt.Errorf("unexpected op in position %d for template '%s'", i, template)
 			}
 		}
-		readOp = !readOp && ch == '%'
+		readOp = !readOp && ch == '%' // Toggle readOp when we encounter a '%'
 	}
+
+	// Handle the case where a '%' is at the end of the template without a following specifier
 	if readOp {
 		return "", fmt.Errorf("non-closed %% in template '%s'", template)
 	}
+
 	return ops, nil
 }
 
+// CompileFilter creates a filter function that transforms strings based on scanf and printf templates.
+// It returns a function that takes a string as input and returns a transformed string and an error.
 func CompileFilter(scanfTemplate, printfTemplate string) (func(req string) (string, error), error) {
+	// Extract the format specifiers from both templates
 	ops, err := parseScanfOps(scanfTemplate)
 	if err != nil {
 		return nil, err
@@ -50,11 +61,17 @@ func CompileFilter(scanfTemplate, printfTemplate string) (func(req string) (stri
 	if err != nil {
 		return nil, err
 	}
+
+	// Validate that the printf template's operators are a prefix of the scanf template's operators.
+	// This ensures that the printf template has access to all the values it needs.
 	if !strings.HasPrefix(ops, printfOps) {
 		return nil, fmt.Errorf("template ops for scanf don't match scanf ops: '%s' != '%s'", ops, printfOps)
 	}
 
+	// Create and return the appropriate filter function based on the extracted format specifiers.
+	// This is where the function behaves differently based on how many and which types of template ops are present
 	if ops == "" {
+		// Case: No format specifiers in either template.  Simple string comparison and replacement.
 		return func(req string) (string, error) {
 			if req == scanfTemplate {
 				return printfTemplate, nil
@@ -62,14 +79,21 @@ func CompileFilter(scanfTemplate, printfTemplate string) (func(req string) (stri
 			return "", errors.New("doesn't match template")
 		}, nil
 	} else if ops == "%d" {
+		// Case: Single integer format specifier.
 		return func(req string) (string, error) {
-			var v1 int64
+			var v1 int64 // Use int64 to handle larger numbers
+			// Use fmt.Sscanf to parse the input according to the scanfTemplate.
+			// It reads the input string req, tries to match it against scanfTemplate,
+			// and stores the extracted value in the v1 variable (if successful).
 			if _, err := fmt.Sscanf(req, scanfTemplate, &v1); err != nil {
 				return "", err
 			}
+			// If parsing succeeds, use fmt.Sprintf to format the output string according to
+			// the printfTemplate and the extracted value v1.
 			return fmt.Sprintf(printfTemplate, v1), nil
 		}, nil
 	} else if ops == "%s" {
+		// Case: Single string format specifier.
 		return func(req string) (string, error) {
 			var v1 string
 			if _, err := fmt.Sscanf(req, scanfTemplate, &v1); err != nil {
@@ -78,6 +102,7 @@ func CompileFilter(scanfTemplate, printfTemplate string) (func(req string) (stri
 			return fmt.Sprintf(printfTemplate, v1), nil
 		}, nil
 	} else if ops == "%d%d" {
+		// Case: Two integer format specifiers.
 		return func(req string) (string, error) {
 			var v1 int64
 			var v2 int64
@@ -87,6 +112,7 @@ func CompileFilter(scanfTemplate, printfTemplate string) (func(req string) (stri
 			return fmt.Sprintf(printfTemplate, v1, v2), nil
 		}, nil
 	} else if ops == "%d%s" {
+		// Case: Integer followed by string format specifier.
 		return func(req string) (string, error) {
 			var v1 int64
 			var v2 string
@@ -96,6 +122,7 @@ func CompileFilter(scanfTemplate, printfTemplate string) (func(req string) (stri
 			return fmt.Sprintf(printfTemplate, v1, v2), nil
 		}, nil
 	} else if ops == "%s%d" {
+		// Case: String followed by integer format specifier.
 		return func(req string) (string, error) {
 			var v1 string
 			var v2 int64
@@ -105,6 +132,7 @@ func CompileFilter(scanfTemplate, printfTemplate string) (func(req string) (stri
 			return fmt.Sprintf(printfTemplate, v1, v2), nil
 		}, nil
 	} else if ops == "%s%s" {
+		// Case: Two string format specifiers.
 		return func(req string) (string, error) {
 			var v1 string
 			var v2 string
@@ -114,6 +142,7 @@ func CompileFilter(scanfTemplate, printfTemplate string) (func(req string) (stri
 			return fmt.Sprintf(printfTemplate, v1, v2), nil
 		}, nil
 	} else {
+		// Case: Unsupported combination of format specifiers.
 		return nil, errors.New("unknown combination of scanf operations")
 	}
 }

--- a/utils/fmtfilter/fmt_test.go
+++ b/utils/fmtfilter/fmt_test.go
@@ -16,26 +16,94 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompileFilter(t *testing.T) {
-	_, err := CompileFilter("%d", "")
+func TestParseScanfOps_NormalFormatSpecifiers(t *testing.T) {
+	ops, err := parseScanfOps("Hello %d World %s")
 	require.NoError(t, err)
-	_, err = CompileFilter("%d", "%s")
-	require.Error(t, err, "template ops for scanf don't match scanf ops")
-	_, err = CompileFilter("%d%s", "%s")
-	require.Error(t, err, "template ops for scanf don't match scanf ops")
-	_, err = CompileFilter("dd%d%sdd", "dd%sss")
-	require.Error(t, err, "template ops for scanf don't match scanf ops")
-	_, err = CompileFilter("dd%d%sdd", "%%")
+	require.Equal(t, "%d%s", ops)
+}
+
+func TestParseScanfOps_EscapedPercentSigns(t *testing.T) {
+	ops, err := parseScanfOps("100%% sure that %d is a number")
 	require.NoError(t, err)
+	require.Equal(t, "%d", ops)
+}
 
-	_, err = CompileFilter("%", "%s")
-	require.Error(t, err, "non-closed %")
-	_, err = CompileFilter("%s", "%5")
-	require.Error(t, err, "non-closed %")
+func TestParseScanfOps_NonLetterCharactersBetweenPercentAndSpecifier(t *testing.T) {
+	ops, err := parseScanfOps("Text with %123d and %456s")
+	require.NoError(t, err)
+	require.Equal(t, "%d%s", ops)
+}
 
-	_, err = CompileFilter("%f", "%s")
-	require.Error(t, err, "unexpected op in position")
+func TestParseScanfOps_InvalidFormatSpecifier(t *testing.T) {
+	_, err := parseScanfOps("Invalid %f format")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected op")
+}
 
+func TestParseScanfOps_NonClosedPercentAtEnd(t *testing.T) {
+	_, err := parseScanfOps("Incomplete format %")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-closed %")
+}
+
+func TestParseScanfOps_EmptyString(t *testing.T) {
+	ops, err := parseScanfOps("")
+	require.NoError(t, err)
+	require.Equal(t, "", ops)
+}
+
+func TestCompileFilter_TemplateOpsMismatch1(t *testing.T) {
+	_, err := CompileFilter("%d", "%s")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "template ops for scanf don't match scanf ops")
+}
+
+func TestCompileFilter_TemplateOpsMismatch2(t *testing.T) {
+	_, err := CompileFilter("%d%s", "%s")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "template ops for scanf don't match scanf ops")
+}
+
+func TestCompileFilter_TemplateOpsMismatch3(t *testing.T) {
+	_, err := CompileFilter("dd%d%sdd", "dd%sss")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "template ops for scanf don't match scanf ops")
+}
+
+func TestCompileFilter_TemplatesNoFormatSpecifiersDifferentStrings(t *testing.T) {
+	_, err := CompileFilter("dd%d%sdd", "%%")
+	require.NoError(t, err)
+}
+
+func TestCompileFilter_ErrorFromParseScanfOps_NonClosedPercent(t *testing.T) {
+	_, err := CompileFilter("%", "%s")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-closed %")
+}
+
+func TestCompileFilter_ErrorFromParseScanfOps_NonClosedPercent2(t *testing.T) {
+	_, err := CompileFilter("%s", "%5")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-closed %")
+}
+
+func TestCompileFilter_ErrorFromParseScanfOps_UnexpectedOp(t *testing.T) {
+	_, err := CompileFilter("%f", "%s")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected op")
+}
+
+func TestCompileFilter_EmptyOpsCase(t *testing.T) {
+	fn, err := CompileFilter("hello", "world")
+	require.NoError(t, err)
+	res, err := fn("hello")
+	require.NoError(t, err)
+	require.Equal(t, "world", res)
+	_, err = fn("not hello")
+	require.Error(t, err)
+}
+
+func TestCompileFilter_PercentDCase(t *testing.T) {
 	fn, err := CompileFilter("qw%der", "ty%dui")
 	require.NoError(t, err)
 	_, err = fn("123")
@@ -49,20 +117,70 @@ func TestCompileFilter(t *testing.T) {
 	res, err := fn("qw123er")
 	require.NoError(t, err)
 	require.Equal(t, "ty123ui", res)
+}
 
-	fn, err = CompileFilter("qw%d%2s123%%", "--%d__%s~~%%")
+func TestCompileFilter_PercentSCase(t *testing.T) {
+	fn, err := CompileFilter("text %s", "output %s")
+	require.NoError(t, err)
+	res, err := fn("text hello")
+	require.NoError(t, err)
+	require.Equal(t, "output hello", res)
+	_, err = fn("invalid input")
+	require.Error(t, err)
+}
+
+func TestCompileFilter_PercentDPercentDCase(t *testing.T) {
+	fn, err := CompileFilter("nums %d and %d", "values %d,%d")
+	require.NoError(t, err)
+	res, err := fn("nums 123 and 456")
+	require.NoError(t, err)
+	require.Equal(t, "values 123,456", res)
+	_, err = fn("invalid input")
+	require.Error(t, err)
+}
+
+func TestCompileFilter_PercentDPercentSCase_EdgeCases(t *testing.T) {
+	fn, err := CompileFilter("qw%d%2s123%%", "--%d__%s~~%%")
 	require.NoError(t, err)
 	_, err = fn("qw456AB123")
 	require.Error(t, err)
-	res, err = fn("qw456AB123%")
+	res, err := fn("qw456AB123%")
 	require.NoError(t, err)
 	require.Equal(t, "--456__AB~~%", res)
+}
 
-	fn, err = CompileFilter("qw%d%2s123", "--%d__%s~~")
+func TestCompileFilter_PercentDPercentSCase_EdgeCases2(t *testing.T) {
+	fn, err := CompileFilter("qw%d%2s123", "--%d__%s~~")
 	require.NoError(t, err)
 	_, err = fn("qw456ABC123")
 	require.Error(t, err)
-	res, err = fn("qw456AB123")
+	res, err := fn("qw456AB123")
 	require.NoError(t, err)
 	require.Equal(t, "--456__AB~~", res)
+}
+
+func TestCompileFilter_PercentSPercentDCase(t *testing.T) {
+	fn, err := CompileFilter("text %s number %d", "result: %s-%d")
+	require.NoError(t, err)
+	res, err := fn("text hello number 42")
+	require.NoError(t, err)
+	require.Equal(t, "result: hello-42", res)
+	_, err = fn("invalid input")
+	require.Error(t, err)
+}
+
+func TestCompileFilter_PercentSPercentSCase(t *testing.T) {
+	fn, err := CompileFilter("words %s and %s", "%s+%s")
+	require.NoError(t, err)
+	res, err := fn("words foo and bar")
+	require.NoError(t, err)
+	require.Equal(t, "foo+bar", res)
+	_, err = fn("invalid input")
+	require.Error(t, err)
+}
+
+func TestCompileFilter_UnsupportedCombinations(t *testing.T) {
+	_, err := CompileFilter("%d%d%d", "%d%d%d")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown combination of scanf operations")
 }


### PR DESCRIPTION
This PR boosts `utils/fmtfilter` test coverage and adds comments to fmtfilter so it is easier to follow.

It is currently placed into `consensus` with the anticipation that it will be migrated to the `kvdb` repository.

Verification:

![image](https://github.com/user-attachments/assets/1a9b986d-5242-434d-8981-2e1e43a34778)
