### PR TITLE
[part 1] `abft` package unit tests and minor cleanup

### DIFF
--- a/abft/bootstrap.go
+++ b/abft/bootstrap.go
@@ -64,30 +64,11 @@ func (p *Orderer) Bootstrap(callback OrdererCallbacks) error {
 	return err
 }
 
-// StartFrom initiates Orderer with specified parameters
-func (p *Orderer) StartFrom(callback OrdererCallbacks, epoch idx.Epoch, validators *pos.Validators) error {
-	if p.election != nil {
-		return errors.New("already bootstrapped")
-	}
-	// block handler must be set before p.handleElection
-	p.callback = callback
-
-	p.store.applyGenesis(epoch, validators)
-	// reset internal epoch DB
-	err := p.resetEpochStore(epoch)
-	if err != nil {
-		return err
-	}
-	if p.callback.EpochDBLoaded != nil {
-		p.callback.EpochDBLoaded(p.store.GetEpoch())
-	}
-	p.election = election.New(FirstFrame, p.store.GetValidators(), p.dagIndex.ForklessCause, p.store.GetFrameRoots)
-	return err
-}
-
 // Reset switches epoch state to a new empty epoch.
 func (p *Orderer) Reset(epoch idx.Epoch, validators *pos.Validators) error {
-	p.store.applyGenesis(epoch, validators)
+	if err := p.store.switchGensis(&Genesis{Epoch: epoch, Validators: validators}); err != nil {
+		return err
+	}
 	// reset internal epoch DB
 	err := p.resetEpochStore(epoch)
 	if err != nil {

--- a/abft/bootstrap.go
+++ b/abft/bootstrap.go
@@ -66,7 +66,7 @@ func (p *Orderer) Bootstrap(callback OrdererCallbacks) error {
 
 // Reset switches epoch state to a new empty epoch.
 func (p *Orderer) Reset(epoch idx.Epoch, validators *pos.Validators) error {
-	if err := p.store.switchGensis(&Genesis{Epoch: epoch, Validators: validators}); err != nil {
+	if err := p.store.switchGenesis(&Genesis{Epoch: epoch, Validators: validators}); err != nil {
 		return err
 	}
 	// reset internal epoch DB

--- a/abft/check_against_db.go
+++ b/abft/check_against_db.go
@@ -32,7 +32,7 @@ func CheckEpochAgainstDB(conn *sql.DB, epoch idx.Epoch) error {
 	}
 	testLachesis, _, eventStore, _ := NewCoreLachesis(validators, weights)
 	// Plant the real epoch state for the sake of event hash calculation (epoch=1 by default)
-	testLachesis.store.applyGenesis(epoch, testLachesis.store.GetValidators())
+	testLachesis.store.switchGensis(&Genesis{Epoch: epoch, Validators: testLachesis.store.GetValidators()})
 
 	recalculatedAtropoi := make([]hash.Event, 0)
 	// Capture the elected atropoi by planting the `applyBlock` callback (nil by default)

--- a/abft/check_against_db.go
+++ b/abft/check_against_db.go
@@ -32,7 +32,7 @@ func CheckEpochAgainstDB(conn *sql.DB, epoch idx.Epoch) error {
 	}
 	testLachesis, _, eventStore, _ := NewCoreLachesis(validators, weights)
 	// Plant the real epoch state for the sake of event hash calculation (epoch=1 by default)
-	testLachesis.store.switchGensis(&Genesis{Epoch: epoch, Validators: testLachesis.store.GetValidators()})
+	testLachesis.store.switchGenesis(&Genesis{Epoch: epoch, Validators: testLachesis.store.GetValidators()})
 
 	recalculatedAtropoi := make([]hash.Event, 0)
 	// Capture the elected atropoi by planting the `applyBlock` callback (nil by default)

--- a/abft/genesis.go
+++ b/abft/genesis.go
@@ -27,10 +27,10 @@ func (s *Store) ApplyGenesis(g *Genesis) error {
 	if ok, _ := s.table.LastDecidedState.Has([]byte(dsKey)); ok {
 		return fmt.Errorf("genesis already applied")
 	}
-	return s.switchGensis(g)
+	return s.switchGenesis(g)
 }
 
-func (s *Store) switchGensis(g *Genesis) error {
+func (s *Store) switchGenesis(g *Genesis) error {
 	if g == nil {
 		return fmt.Errorf("genesis config shouldn't be nil")
 	}

--- a/abft/genesis.go
+++ b/abft/genesis.go
@@ -23,32 +23,26 @@ type Genesis struct {
 	Validators *pos.Validators
 }
 
-// ApplyGenesis writes initial state.
 func (s *Store) ApplyGenesis(g *Genesis) error {
+	if ok, _ := s.table.LastDecidedState.Has([]byte(dsKey)); ok {
+		return fmt.Errorf("genesis already applied")
+	}
+	return s.switchGensis(g)
+}
+
+func (s *Store) switchGensis(g *Genesis) error {
 	if g == nil {
 		return fmt.Errorf("genesis config shouldn't be nil")
 	}
 	if g.Validators.Len() == 0 {
 		return fmt.Errorf("genesis validators shouldn't be empty")
 	}
-	if ok, _ := s.table.LastDecidedState.Has([]byte(dsKey)); ok {
-		return fmt.Errorf("genesis already applied")
-	}
-
-	s.applyGenesis(g.Epoch, g.Validators)
-	return nil
-}
-
-// applyGenesis switches epoch state to a new empty epoch.
-func (s *Store) applyGenesis(epoch idx.Epoch, validators *pos.Validators) {
 	es := &EpochState{}
 	ds := &LastDecidedState{}
-
-	es.Validators = validators
-	es.Epoch = epoch
+	es.Validators = g.Validators
+	es.Epoch = g.Epoch
 	ds.LastDecidedFrame = FirstFrame - 1
-
 	s.SetEpochState(es)
 	s.SetLastDecidedState(ds)
-
+	return nil
 }

--- a/abft/genesis_test.go
+++ b/abft/genesis_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGenesis_Sucess(t *testing.T) {
-	store := NewLiteStore()
+	store := NewMemStore()
 	validatorBuilder := pos.NewBuilder()
 	validatorBuilder.Set(1, 10)
 	validators := validatorBuilder.Build()
@@ -35,16 +35,13 @@ func TestGenesis_Sucess(t *testing.T) {
 	}
 }
 func TestGenesis_Fail(t *testing.T) {
-	store := NewLiteStore()
-
+	store := NewMemStore()
 	if err := store.ApplyGenesis(nil); err == nil {
 		t.Fatal("error expected but not received")
 	}
-
 	if err := store.ApplyGenesis(&Genesis{Epoch: 1, Validators: &pos.Validators{}}); err == nil {
 		t.Fatal("error expected but not received")
 	}
-
 	validatorBuilder := pos.NewBuilder()
 	validatorBuilder.Set(1, 10)
 	store.table.LastDecidedState.Put([]byte(dsKey), []byte{})

--- a/abft/genesis_test.go
+++ b/abft/genesis_test.go
@@ -1,0 +1,54 @@
+package abft
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/inter/pos"
+)
+
+func TestGenesis_Sucess(t *testing.T) {
+	store := NewLiteStore()
+	validatorBuilder := pos.NewBuilder()
+	validatorBuilder.Set(1, 10)
+	validators := validatorBuilder.Build()
+	epoch := idx.Epoch(3)
+	if err := store.ApplyGenesis(&Genesis{Epoch: epoch, Validators: validators}); err != nil {
+		t.Fatal(err)
+	}
+	epochState, exists := store.get(store.table.EpochState, []byte(esKey), &EpochState{}).(*EpochState)
+	if !exists {
+		t.Fatal("epoch state not set")
+	}
+	if want, got := epochState.Epoch, epoch; want != got {
+		t.Fatalf("expected set epoch: %d, got: %d", want, got)
+	}
+	if want, got := epochState.Validators.Get(1), validators.Get(1); want != got {
+		t.Fatalf("expected set validator weight: %d, got: %d", want, got)
+	}
+	lastDecidedState, exists := store.get(store.table.LastDecidedState, []byte(dsKey), &LastDecidedState{}).(*LastDecidedState)
+	if !exists {
+		t.Fatal("last decided state not set")
+	}
+	if want, got := lastDecidedState.LastDecidedFrame, FirstFrame-1; want != got {
+		t.Fatalf("expected frame for last state: %d, got: %d", want, got)
+	}
+}
+func TestGenesis_Fail(t *testing.T) {
+	store := NewLiteStore()
+
+	if err := store.ApplyGenesis(nil); err == nil {
+		t.Fatal("error expected but not received")
+	}
+
+	if err := store.ApplyGenesis(&Genesis{Epoch: 1, Validators: &pos.Validators{}}); err == nil {
+		t.Fatal("error expected but not received")
+	}
+
+	validatorBuilder := pos.NewBuilder()
+	validatorBuilder.Set(1, 10)
+	store.table.LastDecidedState.Put([]byte(dsKey), []byte{})
+	if err := store.ApplyGenesis(&Genesis{Epoch: 1, Validators: validatorBuilder.Build()}); err == nil {
+		t.Fatal("error expected but not received")
+	}
+}

--- a/abft/lachesis.go
+++ b/abft/lachesis.go
@@ -107,19 +107,6 @@ func (p *Lachesis) BootstrapWithOrderer(callback lachesis.ConsensusCallbacks, or
 	return nil
 }
 
-func (p *Lachesis) StartFrom(callback lachesis.ConsensusCallbacks, epoch idx.Epoch, validators *pos.Validators) error {
-	return p.StartFromWithOrderer(callback, epoch, validators, p.OrdererCallbacks())
-}
-
-func (p *Lachesis) StartFromWithOrderer(callback lachesis.ConsensusCallbacks, epoch idx.Epoch, validators *pos.Validators, ordererCallbacks OrdererCallbacks) error {
-	err := p.Orderer.StartFrom(ordererCallbacks, epoch, validators)
-	if err != nil {
-		return err
-	}
-	p.callback = callback
-	return nil
-}
-
 func (p *Lachesis) OrdererCallbacks() OrdererCallbacks {
 	return OrdererCallbacks{
 		ApplyAtropos: p.applyAtropos,

--- a/abft/store_test.go
+++ b/abft/store_test.go
@@ -1,13 +1,19 @@
 package abft
 
 import (
+	"math/rand"
+	"slices"
 	"testing"
 
+	"github.com/0xsoniclabs/consensus/abft/election"
+	"github.com/0xsoniclabs/consensus/inter/dag/tdag"
+	"github.com/0xsoniclabs/consensus/inter/idx"
 	"github.com/0xsoniclabs/consensus/inter/pos"
 )
 
-func TestStore_StateSetting(t *testing.T) {
-	store, epochState, lastDecidedState := newPopulatedStore()
+func TestStore_StatePersisting(t *testing.T) {
+	store := NewMemStore()
+	epochState, lastDecidedState := populateWithEpochStates(store)
 	if want, got := epochState, store.GetEpochState(); want.Epoch != got.Epoch || want.Validators.TotalWeight() != got.Validators.TotalWeight() {
 		t.Fatalf("incorrect epoch state retrieved. expected: %v, got: %v", want, got)
 	}
@@ -16,8 +22,32 @@ func TestStore_StateSetting(t *testing.T) {
 	}
 }
 
+func TestStore_FrameRootPersisting(t *testing.T) {
+	store := NewMemStore()
+	roots := populateWithRoots(store)
+	retrievalOrder := make([]int, len(roots))
+	for i := range len(roots) {
+		retrievalOrder[i] = i
+	}
+	rand.Shuffle(len(retrievalOrder), func(i, j int) { retrievalOrder[i], retrievalOrder[j] = retrievalOrder[j], retrievalOrder[i] })
+	for _, frame := range retrievalOrder {
+		frameRoots := store.GetFrameRoots(idx.Frame(frame))
+		if want, got := len(roots[frame]), len(frameRoots); want != got {
+			t.Fatalf("incorrect number of roots retrieved for frame %d, expected: %d, got: %d", frame, want, got)
+		}
+		slices.SortFunc(frameRoots, func(r1, r2 election.RootContext) int { return int(r1.ValidatorID) - int(r2.ValidatorID) })
+		for validatorID := range len(frameRoots) {
+			if want, got := roots[frame][validatorID].ID(), frameRoots[validatorID].RootHash; want != got {
+				t.Fatalf("incorrect root retrieved for [frame, validator]: [%d, %d], expected: %s, got: %s", frame, validatorID, want, got)
+			}
+		}
+	}
+}
+
 func TestStore_Close(t *testing.T) {
-	store, _, _ := newPopulatedStore()
+	store := NewMemStore()
+	populateWithEpochStates(store)
+	populateWithRoots(store)
 	store.Close()
 	if store.table.EpochState != nil {
 		t.Fatalf("expected EpochState table to be nil")
@@ -25,16 +55,32 @@ func TestStore_Close(t *testing.T) {
 	if store.table.LastDecidedState != nil {
 		t.Fatalf("expected LastDecidedState table to be nil")
 	}
+	if store.epochTable.Roots != nil {
+		t.Fatalf("expected Roots table to be nil")
+	}
 }
 
-func newPopulatedStore() (*Store, *EpochState, *LastDecidedState) {
-	store := NewMemStore()
+func populateWithRoots(store *Store) [][]*tdag.TestEvent {
+	store.openEpochDB(1)
+	roots := make([][]*tdag.TestEvent, 100)
+	for frame := range idx.Frame(100) {
+		roots[frame] = make([]*tdag.TestEvent, 100)
+		for validatorID := range idx.ValidatorID(100) {
+			root := &tdag.TestEvent{}
+			root.SetID([24]byte{byte(frame), byte(validatorID)})
+			store.addRoot(root, frame)
+			roots[frame][validatorID] = root
+		}
+	}
+	return roots
+}
+
+func populateWithEpochStates(store *Store) (*EpochState, *LastDecidedState) {
 	validatorBuilder := pos.NewBuilder()
 	validatorBuilder.Set(1, 10)
 	epochState := &EpochState{Epoch: 3, Validators: validatorBuilder.Build()}
 	lastDecidedState := &LastDecidedState{LastDecidedFrame: 5}
 	store.SetEpochState(epochState)
 	store.SetLastDecidedState(lastDecidedState)
-
-	return store, epochState, lastDecidedState
+	return epochState, lastDecidedState
 }

--- a/abft/store_test.go
+++ b/abft/store_test.go
@@ -1,0 +1,40 @@
+package abft
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/consensus/inter/pos"
+)
+
+func TestStore_StateSetting(t *testing.T) {
+	store, epochState, lastDecidedState := newPopulatedStore()
+	if want, got := epochState, store.GetEpochState(); want.Epoch != got.Epoch || want.Validators.TotalWeight() != got.Validators.TotalWeight() {
+		t.Fatalf("incorrect epoch state retrieved. expected: %v, got: %v", want, got)
+	}
+	if want, got := lastDecidedState, store.GetLastDecidedState(); want.LastDecidedFrame != got.LastDecidedFrame {
+		t.Fatalf("incorrect last decided state retrieved. expected: %v, got: %v", want, got)
+	}
+}
+
+func TestStore_Close(t *testing.T) {
+	store, _, _ := newPopulatedStore()
+	store.Close()
+	if store.table.EpochState != nil {
+		t.Fatalf("expected EpochState table to be nil")
+	}
+	if store.table.LastDecidedState != nil {
+		t.Fatalf("expected LastDecidedState table to be nil")
+	}
+}
+
+func newPopulatedStore() (*Store, *EpochState, *LastDecidedState) {
+	store := NewMemStore()
+	validatorBuilder := pos.NewBuilder()
+	validatorBuilder.Set(1, 10)
+	epochState := &EpochState{Epoch: 3, Validators: validatorBuilder.Build()}
+	lastDecidedState := &LastDecidedState{LastDecidedFrame: 5}
+	store.SetEpochState(epochState)
+	store.SetLastDecidedState(lastDecidedState)
+
+	return store, epochState, lastDecidedState
+}

--- a/abft/test_utils.go
+++ b/abft/test_utils.go
@@ -73,14 +73,7 @@ func NewCoreLachesis(nodes []idx.ValidatorID, weights []pos.Weight, mods ...memo
 			validators[v] = weights[i]
 		}
 	}
-
-	openEDB := func(epoch idx.Epoch) kvdb.Store {
-		return memorydb.New()
-	}
-	crit := func(err error) {
-		panic(err)
-	}
-	store := NewStore(memorydb.New(), openEDB, crit, LiteStoreConfig())
+	store := NewLiteStore()
 
 	err := store.ApplyGenesis(&Genesis{
 		Validators: validators.Build(),
@@ -93,6 +86,9 @@ func NewCoreLachesis(nodes []idx.ValidatorID, weights []pos.Weight, mods ...memo
 	input := NewEventStore()
 
 	config := LiteConfig()
+	crit := func(err error) {
+		panic(err)
+	}
 	dagIndexer := &adapters.VectorToDagIndexer{Engine: vecengine.NewIndex(crit, vecengine.LiteConfig(), vecengine.GetEngineCallbacks)}
 	lch := NewIndexedLachesis(store, input, dagIndexer, crit, config)
 
@@ -179,4 +175,14 @@ func (s *EventStore) GetEvent(h hash.Event) dag.Event {
 func (s *EventStore) HasEvent(h hash.Event) bool {
 	_, ok := s.db[h]
 	return ok
+}
+
+func NewLiteStore() *Store {
+	openEDB := func(epoch idx.Epoch) kvdb.Store {
+		return memorydb.New()
+	}
+	crit := func(err error) {
+		panic(err)
+	}
+	return NewStore(memorydb.New(), openEDB, crit, LiteStoreConfig())
 }

--- a/abft/test_utils.go
+++ b/abft/test_utils.go
@@ -20,7 +20,6 @@ import (
 	"github.com/0xsoniclabs/consensus/inter/dag"
 	"github.com/0xsoniclabs/consensus/inter/idx"
 	"github.com/0xsoniclabs/consensus/inter/pos"
-	"github.com/0xsoniclabs/consensus/kvdb"
 	"github.com/0xsoniclabs/consensus/kvdb/memorydb"
 	"github.com/0xsoniclabs/consensus/lachesis"
 	"github.com/0xsoniclabs/consensus/utils/adapters"
@@ -73,7 +72,7 @@ func NewCoreLachesis(nodes []idx.ValidatorID, weights []pos.Weight, mods ...memo
 			validators[v] = weights[i]
 		}
 	}
-	store := NewLiteStore()
+	store := NewMemStore()
 
 	err := store.ApplyGenesis(&Genesis{
 		Validators: validators.Build(),
@@ -175,14 +174,4 @@ func (s *EventStore) GetEvent(h hash.Event) dag.Event {
 func (s *EventStore) HasEvent(h hash.Event) bool {
 	_, ok := s.db[h]
 	return ok
-}
-
-func NewLiteStore() *Store {
-	openEDB := func(epoch idx.Epoch) kvdb.Store {
-		return memorydb.New()
-	}
-	crit := func(err error) {
-		panic(err)
-	}
-	return NewStore(memorydb.New(), openEDB, crit, LiteStoreConfig())
 }


### PR DESCRIPTION
This PR cleans up dead code and adds unit tests for previously poorly covered components - `Genesis` and `Store`. This brings the cumulative coverage of the `abft` package above 90%.  Including these changes, no other public methods are left uncovered in this package and the remaining ~10% are mainly attributed to frequent backwards error propagation.
Eventually, a part 2 PR may be created to address the uncovered code lines after a more radical refactor.