### PR TITLE
Add performance benchmarks for election execution

### DIFF
--- a/abft/atropos_chain_test.go
+++ b/abft/atropos_chain_test.go
@@ -25,6 +25,14 @@ func TestRegressionData_SonicNetwork(t *testing.T) {
 	testRegressionData(t, "testdata/events-8000-partial.db")
 }
 
+func BenchmarkElectionFantomNetwork(b *testing.B) {
+	benchmarkElection(b, "testdata/events-5577.db")
+}
+
+func BenchmarkElectionSonicNetwork(b *testing.B) {
+	benchmarkElection(b, "testdata/events-8000-partial.db")
+}
+
 func testRegressionData(t *testing.T, dbPath string) {
 	conn, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
@@ -55,28 +63,20 @@ func benchmarkElection(b *testing.B, dbPath string) {
 		b.Fatal(err)
 	}
 
-    b.ResetTimer()
+	b.ResetTimer()
 
 	for range b.N {
-	    for epoch := epochMin; epoch <= epochMax; epoch++ {
-            b.StopTimer()
-            testLachesis, eventStore, _, orderedEvents, err := SetupElection(conn, epoch);
-            if err != nil {
-                b.Fatal(err)
-            }
+		for epoch := epochMin; epoch <= epochMax; epoch++ {
+			b.StopTimer()
+			testLachesis, eventStore, _, orderedEvents, err := SetupElection(conn, epoch)
+			if err != nil {
+				b.Fatal(err)
+			}
 
-            b.StartTimer()
-            if err := ExecuteElection(testLachesis, eventStore, orderedEvents); err != nil {
-		        b.Fatal(err)
-            }
-        }
-    }
-}
-
-func BenchmarkElectionFantom(b *testing.B) {
-	benchmarkElection(b, "testdata/events-5577.db")
-}
-
-func BenchmarkElectionSonic(b *testing.B) {
-	benchmarkElection(b, "testdata/events-8000-partial.db")
+			b.StartTimer()
+			if err := ExecuteElection(testLachesis, eventStore, orderedEvents); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
 }

--- a/abft/atropos_chain_test.go
+++ b/abft/atropos_chain_test.go
@@ -42,3 +42,41 @@ func testRegressionData(t *testing.T, dbPath string) {
 		}
 	}
 }
+
+func benchmarkElection(b *testing.B, dbPath string) {
+	conn, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer conn.Close()
+
+	epochMin, epochMax, err := GetEpochRange(conn)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+    b.ResetTimer()
+
+	for range b.N {
+	    for epoch := epochMin; epoch <= epochMax; epoch++ {
+            b.StopTimer()
+            testLachesis, eventStore, _, orderedEvents, err := SetupElection(conn, epoch);
+            if err != nil {
+                b.Fatal(err)
+            }
+
+            b.StartTimer()
+            if err := ExecuteElection(testLachesis, eventStore, orderedEvents); err != nil {
+		        b.Fatal(err)
+            }
+        }
+    }
+}
+
+func BenchmarkElectionFantom(b *testing.B) {
+	benchmarkElection(b, "testdata/events-5577.db")
+}
+
+func BenchmarkElectionSonic(b *testing.B) {
+	benchmarkElection(b, "testdata/events-8000-partial.db")
+}

--- a/abft/atropos_chain_test.go
+++ b/abft/atropos_chain_test.go
@@ -68,13 +68,13 @@ func benchmarkElection(b *testing.B, dbPath string) {
 	for range b.N {
 		for epoch := epochMin; epoch <= epochMax; epoch++ {
 			b.StopTimer()
-			testLachesis, eventStore, _, orderedEvents, err := SetupElection(conn, epoch)
+			testLachesis, eventStore, _, orderedEvents, err := setupElection(conn, epoch)
 			if err != nil {
 				b.Fatal(err)
 			}
 
 			b.StartTimer()
-			if err := ExecuteElection(testLachesis, eventStore, orderedEvents); err != nil {
+			if err := executeElection(testLachesis, eventStore, orderedEvents); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/abft/check_against_db.go
+++ b/abft/check_against_db.go
@@ -39,7 +39,7 @@ func SetupElection(conn *sql.DB, epoch idx.Epoch) (*CoreLachesis, *EventStore, m
 		return nil, nil, nil, nil, err
 	}
 
-    return testLachesis, eventStore, eventMap, eventsOrdered, nil
+	return testLachesis, eventStore, eventMap, eventsOrdered, nil
 }
 
 func ExecuteElection(testLachesis *CoreLachesis, eventStore *EventStore, eventsOrdered []*dbEvent) error {
@@ -49,14 +49,14 @@ func ExecuteElection(testLachesis *CoreLachesis, eventStore *EventStore, eventsO
 		}
 	}
 
-    return nil
+	return nil
 }
 
 func CheckEpochAgainstDB(conn *sql.DB, epoch idx.Epoch) error {
-    testLachesis, eventStore, eventMap, orderedEvents, err := SetupElection(conn, epoch);
-    if err != nil {
-        return err
-    }
+	testLachesis, eventStore, eventMap, orderedEvents, err := SetupElection(conn, epoch)
+	if err != nil {
+		return err
+	}
 
 	recalculatedAtropoi := make([]hash.Event, 0)
 	// Capture the elected atropoi by planting the `applyBlock` callback (nil by default)
@@ -65,9 +65,9 @@ func CheckEpochAgainstDB(conn *sql.DB, epoch idx.Epoch) error {
 		return nil
 	}
 
-    if err := ExecuteElection(testLachesis, eventStore, orderedEvents); err != nil {
-        return err
-    }
+	if err := ExecuteElection(testLachesis, eventStore, orderedEvents); err != nil {
+		return err
+	}
 
 	expectedAtropoi, err := getAtropoi(conn, epoch)
 	if err != nil {

--- a/abft/check_against_db.go
+++ b/abft/check_against_db.go
@@ -44,7 +44,7 @@ func SetupElection(conn *sql.DB, epoch idx.Epoch) (*CoreLachesis, *EventStore, m
 
 func ExecuteElection(testLachesis *CoreLachesis, eventStore *EventStore, eventsOrdered []*dbEvent) error {
 	for _, event := range eventsOrdered {
-		if err := IngestEvent(testLachesis, eventStore, event); err != nil {
+		if err := ingestEvent(testLachesis, eventStore, event); err != nil {
 			return err
 		}
 	}
@@ -106,7 +106,7 @@ func GetEpochRange(conn *sql.DB) (idx.Epoch, idx.Epoch, error) {
 	return epochMin, epochMax, nil
 }
 
-func IngestEvent(testLachesis *CoreLachesis, eventStore *EventStore, event *dbEvent) error {
+func ingestEvent(testLachesis *CoreLachesis, eventStore *EventStore, event *dbEvent) error {
 	testEvent := &tdag.TestEvent{}
 	testEvent.SetSeq(event.seq)
 	testEvent.SetCreator(event.validatorId)

--- a/abft/check_against_db.go
+++ b/abft/check_against_db.go
@@ -22,7 +22,7 @@ import (
 	"github.com/0xsoniclabs/consensus/lachesis"
 )
 
-func SetupElection(conn *sql.DB, epoch idx.Epoch) (*CoreLachesis, *EventStore, map[hash.Event]*dbEvent, []*dbEvent, error) {
+func setupElection(conn *sql.DB, epoch idx.Epoch) (*CoreLachesis, *EventStore, map[hash.Event]*dbEvent, []*dbEvent, error) {
 	validators, weights, err := getValidator(conn, epoch)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -42,7 +42,7 @@ func SetupElection(conn *sql.DB, epoch idx.Epoch) (*CoreLachesis, *EventStore, m
 	return testLachesis, eventStore, eventMap, eventsOrdered, nil
 }
 
-func ExecuteElection(testLachesis *CoreLachesis, eventStore *EventStore, eventsOrdered []*dbEvent) error {
+func executeElection(testLachesis *CoreLachesis, eventStore *EventStore, eventsOrdered []*dbEvent) error {
 	for _, event := range eventsOrdered {
 		if err := ingestEvent(testLachesis, eventStore, event); err != nil {
 			return err
@@ -53,7 +53,7 @@ func ExecuteElection(testLachesis *CoreLachesis, eventStore *EventStore, eventsO
 }
 
 func CheckEpochAgainstDB(conn *sql.DB, epoch idx.Epoch) error {
-	testLachesis, eventStore, eventMap, orderedEvents, err := SetupElection(conn, epoch)
+	testLachesis, eventStore, eventMap, orderedEvents, err := setupElection(conn, epoch)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func CheckEpochAgainstDB(conn *sql.DB, epoch idx.Epoch) error {
 		return nil
 	}
 
-	if err := ExecuteElection(testLachesis, eventStore, orderedEvents); err != nil {
+	if err := executeElection(testLachesis, eventStore, orderedEvents); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- Added benchmarking to time the election execution code (ignoring database querying in setup). 
- Refactored CheckEpochAgainstDB to use common code.  
- Chose to use b.Stop/StartTimer() to avoid storing multiple instances of CoreLachesis, EventStore etc. It seems to work fine and simplifies the code. b.ResetTimer is done for sanity reasons and has been recommended (in forums) if using Stop/StartTimer. It can probably be removed however with no harm. 
- Ran go fmt 

Tests continue to pass and benchmarks seem realistic: 

>psubotic@Pavles-MacBook-Pro-2 abft % go test
>PASS
>ok  	github.com/0xsoniclabs/consensus/abft	14.601s
>psubotic@Pavles-MacBook-Pro-2 abft % go test -bench .
>goos: darwin
>goarch: arm64
>pkg: github.com/0xsoniclabs/consensus/abft
>cpu: Apple M3 Pro
>BenchmarkElectionFantom-12    	       1	2670004292 ns/op
>BenchmarkElectionSonic-12     	       1	4839811750 ns/op
>PASS
>ok  	github.com/0xsoniclabs/consensus/abft	22.445s

As per @Tjofil  suggestion confirmed dbchecker builds