### PR TITLE
Add codecov workflow 

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  range: 50..80 # below 50 is red, between 50-80 is yellow and above 80 is green
+  round: down
+  precision: 2
+  status:
+    patch:
+      default:
+        target: 80% # target coverage of the changes
+        threshold: 1% # allow the coverage to drop by <threshold>%

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,29 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+name: Go
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.24"
+
+      - name: Test
+        run: go test -coverprofile=coverage.txt ./...
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: 0xsoniclabs/consensus


### PR DESCRIPTION
Add test coverage workflow. The coverage rule are set in `.codecov.yml` file as follows:

1. Each change much have at least 80% diff coverage.
2. In the case of code removal, coverage cannot drop more than 1%.

Git actions workflow is triggered when push or create PR toward `main` branch.