### PR TITLE
Make metric type uint based

### DIFF
--- a/consensus/events.go
+++ b/consensus/events.go
@@ -27,7 +27,7 @@ func (ee Events) String() string {
 }
 
 func (ee Events) Metric() (metric Metric) {
-	metric.Num = Seq(len(ee))
+	metric.Num = uint32(len(ee))
 	for _, e := range ee {
 		metric.Size += uint64(e.Size())
 	}

--- a/consensus/metric.go
+++ b/consensus/metric.go
@@ -15,7 +15,7 @@ import (
 )
 
 type Metric struct {
-	Num  Seq
+	Num  uint32
 	Size uint64
 }
 


### PR DESCRIPTION
This change is required as 0xsoniclabs/cacheutils lost its dependency on `Seq` type. Client-side change for this is somewhat more complex. Precision wise, it's safe as `Seq` was `uint32` under the hood.

All tests pass.
