### PR TITLE
Fix staticcheck warnings

### DIFF
--- a/consensus/consensusengine/event_processing.go
+++ b/consensus/consensusengine/event_processing.go
@@ -42,7 +42,7 @@ func (p *Orderer) Build(e consensus.MutableEvent) error {
 // All the event checkers must be launched.
 // Process is not safe for concurrent use.
 func (p *Orderer) Process(e consensus.Event) (err error) {
-	err, selfParentFrame := p.checkAndSaveEvent(e)
+	selfParentFrame, err := p.checkAndSaveEvent(e)
 	if err != nil {
 		return err
 	}
@@ -75,17 +75,17 @@ func (p *Orderer) ProcessLocalEvent(e consensus.Event) (err error) {
 }
 
 // checkAndSaveEvent checks consensus-related fields: Frame, IsRoot
-func (p *Orderer) checkAndSaveEvent(e consensus.Event) (error, consensus.Frame) {
+func (p *Orderer) checkAndSaveEvent(e consensus.Event) (consensus.Frame, error) {
 	// check frame & isRoot
 	selfParentFrame, frameIdx := p.calcFrameIdx(e)
 	if !p.config.SuppressFramePanic && e.Frame() != frameIdx {
-		return ErrWrongFrame, 0
+		return 0, ErrWrongFrame
 	}
 
 	if selfParentFrame != frameIdx {
 		p.store.AddRoot(e)
 	}
-	return nil, selfParentFrame
+	return selfParentFrame, nil
 }
 
 // calculates Atropos election for the root, calls p.onFrameDecided if election was decided

--- a/consensus/consensusengine/event_processing_test.go
+++ b/consensus/consensusengine/event_processing_test.go
@@ -13,7 +13,7 @@ package consensusengine
 import (
 	"errors"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -118,7 +118,7 @@ func testLachesisRandomAndReset(t *testing.T, weights []consensus.Weight, mutate
 		parentCount = len(nodes)
 	}
 	epochStates := map[consensus.Epoch]*consensusstore.EpochState{}
-	r := rand.New(rand.NewSource(int64(len(nodes) + cheatersCount))) // nolint:gosec
+	r := consensustest.NewIntSeededRandGenerator(uint64(len(nodes) + cheatersCount))
 	for epoch := consensus.Epoch(1); epoch <= consensus.Epoch(epochs); epoch++ {
 		consensustest.ForEachRandFork(nodes, nodes[:cheatersCount], eventCount, parentCount, 10, r, consensustest.ForEachEvent{
 			Process: func(e consensus.Event, name string) {
@@ -145,7 +145,7 @@ func testLachesisRandomAndReset(t *testing.T, weights []consensus.Weight, mutate
 	// connect events to other instances
 	for epoch := consensus.Epoch(1); epoch <= consensus.Epoch(epochs); epoch++ {
 		for i := 1; i < len(lchs); i++ {
-			if reset && epoch != epochs-1 && r.Intn(2) == 0 {
+			if reset && epoch != epochs-1 && r.IntN(2) == 0 {
 				// never reset last epoch to be able to compare latest state
 				resetEpoch := epoch + 1
 				err := lchs[i].Reset(resetEpoch, epochStates[resetEpoch].Validators)

--- a/consensus/consensusengine/frame_decide_test.go
+++ b/consensus/consensusengine/frame_decide_test.go
@@ -12,7 +12,6 @@ package consensusengine
 
 import (
 	"math"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -84,7 +83,7 @@ func testConfirmBlocks(t *testing.T, weights []consensus.Weight, cheatersCount i
 	if parentCount > len(nodes) {
 		parentCount = len(nodes)
 	}
-	r := rand.New(rand.NewSource(int64(len(nodes) + cheatersCount))) // nolint:gosec
+	r := consensustest.NewIntSeededRandGenerator(uint64(len(nodes) + cheatersCount))
 	consensustest.ForEachRandFork(nodes, nodes[:cheatersCount], eventCount, parentCount, 10, r, consensustest.ForEachEvent{
 		Process: func(e consensus.Event, name string) {
 			input.SetEvent(e)

--- a/consensus/consensusengine/restart_test.go
+++ b/consensus/consensusengine/restart_test.go
@@ -13,7 +13,6 @@ package consensusengine
 import (
 	"errors"
 	"math"
-	"math/rand"
 	"testing"
 
 	"github.com/0xsoniclabs/consensus/consensus"
@@ -122,7 +121,7 @@ func testRestartAndReset(t *testing.T, weights []consensus.Weight, mutateWeights
 		parentCount = len(nodes)
 	}
 	epochStates := map[consensus.Epoch]*consensusstore.EpochState{}
-	r := rand.New(rand.NewSource(int64(len(nodes) + cheatersCount))) // nolint:gosec
+	r := consensustest.NewIntSeededRandGenerator(uint64(len(nodes) + cheatersCount))
 	for epoch := consensus.Epoch(1); epoch <= consensus.Epoch(epochs); epoch++ {
 		consensustest.ForEachRandFork(nodes, nodes[:cheatersCount], eventCount, parentCount, 10, r, consensustest.ForEachEvent{
 			Process: func(e consensus.Event, name string) {
@@ -153,7 +152,7 @@ func testRestartAndReset(t *testing.T, weights []consensus.Weight, mutateWeights
 		if e.Epoch() < resetEpoch {
 			continue
 		}
-		if resets && epochStates[e.Epoch()+2] != nil && r.Intn(30) == 0 {
+		if resets && epochStates[e.Epoch()+2] != nil && r.IntN(30) == 0 {
 			// never reset last epoch to be able to compare latest state
 			resetEpoch = e.Epoch() + 1
 			err := lchs[EXPECTED].Reset(resetEpoch, epochStates[resetEpoch].Validators)
@@ -164,7 +163,7 @@ func testRestartAndReset(t *testing.T, weights []consensus.Weight, mutateWeights
 		if e.Epoch() < resetEpoch {
 			continue
 		}
-		if r.Intn(10) == 0 {
+		if r.IntN(10) == 0 {
 			prev := lchs[RESTORED]
 
 			store := consensusstore.NewMemStore()

--- a/consensus/consensusengine/test_utils.go
+++ b/consensus/consensusengine/test_utils.go
@@ -11,8 +11,6 @@
 package consensusengine
 
 import (
-	"math/rand"
-
 	"github.com/0xsoniclabs/consensus/consensus"
 	"github.com/0xsoniclabs/consensus/consensus/consensusstore"
 	"github.com/0xsoniclabs/consensus/consensus/consensustest"
@@ -116,10 +114,10 @@ func NewCoreLachesis(nodes []consensus.ValidatorID, weights []consensus.Weight, 
 }
 
 func mutateValidators(validators *consensus.Validators) *consensus.Validators {
-	r := rand.New(rand.NewSource(int64(validators.TotalWeight()))) // nolint:gosec
+	r := consensustest.NewIntSeededRandGenerator(uint64(validators.TotalWeight()))
 	builder := consensus.NewBuilder()
 	for _, vid := range validators.IDs() {
-		stake := uint64(validators.Get(vid))*uint64(500+r.Intn(500))/1000 + 1
+		stake := uint64(validators.Get(vid))*uint64(500+r.IntN(500))/1000 + 1
 		builder.Set(vid, consensus.Weight(stake))
 	}
 	return builder.Build()

--- a/consensus/consensusstore/store_test.go
+++ b/consensus/consensusstore/store_test.go
@@ -1,7 +1,7 @@
 package consensusstore
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"slices"
 	"testing"
 

--- a/consensus/consensustest/ascii_scheme.go
+++ b/consensus/consensustest/ascii_scheme.go
@@ -89,7 +89,6 @@ func ASCIIschemeForEach(
 					nLinks[last][col] = 2
 				}
 			case "╫", "║", "║║": // don't mutate link array
-				break
 			default:
 				if strings.HasPrefix(symbol, "║") || strings.HasSuffix(symbol, "║") {
 					// it is a far ref

--- a/consensus/consensustest/test_events_test.go
+++ b/consensus/consensustest/test_events_test.go
@@ -11,7 +11,7 @@
 package consensustest
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/0xsoniclabs/consensus/consensus"

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,7 @@
 
 module github.com/0xsoniclabs/consensus
 
-go 1.22.0
-
-toolchain go1.23.6
+go 1.24.0
 
 require (
 	github.com/0xsoniclabs/cacheutils v0.0.0-20250320134355-5a9aa4df3861

--- a/vecengine/forkless_cause.go
+++ b/vecengine/forkless_cause.go
@@ -50,7 +50,7 @@ func (vi *Engine) forklessCause(aID, bID consensus.EventHash) bool {
 	// Get events by hash
 	a := vi.GetHighestBefore(aID)
 	if a == nil {
-		vi.crit(fmt.Errorf("Event A=%s not found", aID.String()))
+		vi.crit(fmt.Errorf("event A=%s not found", aID.String()))
 		return false
 	}
 
@@ -65,7 +65,7 @@ func (vi *Engine) forklessCause(aID, bID consensus.EventHash) bool {
 	// check A observes that {QUORUM} non-cheater-validators observe B
 	b := vi.GetLowestAfter(bID)
 	if b == nil {
-		vi.crit(fmt.Errorf("Event B=%s not found", bID.String()))
+		vi.crit(fmt.Errorf("event B=%s not found", bID.String()))
 		return false
 	}
 
@@ -104,7 +104,7 @@ func (vi *Engine) ForklessCauseProgress(aID, bID consensus.EventHash, candidateP
 
 	// create the counters that measure the forkless cause progress
 	candidateParentsFCProgress := make([]*consensus.WeightCounter, len(candidateParents))
-	for i, _ := range candidateParentsFCProgress {
+	for i := range candidateParentsFCProgress {
 		candidateParentsFCProgress[i] = vi.validators.NewCounter() // initialise the counter for each candidate parent
 	}
 	chosenParentsFCProgress := vi.validators.NewCounter() // initialise the counter for chosen parents only
@@ -112,24 +112,24 @@ func (vi *Engine) ForklessCauseProgress(aID, bID consensus.EventHash, candidateP
 	// Get events by hash
 	aHB := vi.GetHighestBefore(aID)
 	if aHB == nil {
-		vi.crit(fmt.Errorf("Event A=%s not found", aID.String()))
+		vi.crit(fmt.Errorf("event A=%s not found", aID.String()))
 		return chosenParentsFCProgress, candidateParentsFCProgress
 	}
 
 	candidateParentsHB := make([]*HighestBeforeSeq, len(candidateParents))
-	for i, _ := range candidateParents {
+	for i := range candidateParents {
 		candidateParentsHB[i] = vi.GetHighestBefore(candidateParents[i])
 		if candidateParentsHB[i] == nil {
-			vi.crit(fmt.Errorf("Candidate parent=%s not found", candidateParents[i].String()))
+			vi.crit(fmt.Errorf("candidate parent=%s not found", candidateParents[i].String()))
 			return chosenParentsFCProgress, candidateParentsFCProgress
 		}
 	}
 
 	chosenParentsHB := make([]*HighestBeforeSeq, len(chosenParents))
-	for i, _ := range chosenParents {
+	for i := range chosenParents {
 		chosenParentsHB[i] = vi.GetHighestBefore(chosenParents[i])
 		if chosenParentsHB[i] == nil {
-			vi.crit(fmt.Errorf("Chosen parent=%s not found", chosenParents[i].String()))
+			vi.crit(fmt.Errorf("chosen parent=%s not found", chosenParents[i].String()))
 			return chosenParentsFCProgress, candidateParentsFCProgress
 		}
 	}
@@ -164,7 +164,7 @@ func (vi *Engine) ForklessCauseProgress(aID, bID consensus.EventHash, candidateP
 
 	bLA := vi.GetLowestAfter(bID)
 	if bLA == nil {
-		vi.crit(fmt.Errorf("Event B=%s not found", bID.String()))
+		vi.crit(fmt.Errorf("event B=%s not found", bID.String()))
 		return chosenParentsFCProgress, candidateParentsFCProgress
 	}
 
@@ -179,7 +179,7 @@ func (vi *Engine) ForklessCauseProgress(aID, bID consensus.EventHash, candidateP
 
 		IsForkDetected := HighestBefore.IsForkDetected()
 
-		for i, _ := range chosenParents {
+		for i := range chosenParents {
 			chosenParentHighestBefore := chosenParentsHB[i].Get(branchID)                  // highest event from creator, observed by a chosen parent
 			HighestBefore.Seq = maxEvent(HighestBefore.Seq, chosenParentHighestBefore.Seq) // find HighestBefore as observed by a and all chosen parents
 			IsForkDetected = IsForkDetected || chosenParentHighestBefore.IsForkDetected()
@@ -192,7 +192,7 @@ func (vi *Engine) ForklessCauseProgress(aID, bID consensus.EventHash, candidateP
 			chosenParentsFCProgress.CountByIdx(creatorIdx)
 		}
 		// now do forkless cause for a + chosenParents + each candidate parent
-		for i, _ := range candidateParents {
+		for i := range candidateParents {
 			candidateParentHighestBefore := candidateParentsHB[i].Get(branchID)
 			candidateParentIsForkDetected := IsForkDetected || candidateParentHighestBefore.IsForkDetected()
 			candidateParentHighestBefore.Seq = maxEvent(HighestBefore.Seq, candidateParentHighestBefore.Seq)

--- a/vecengine/forkless_cause_test.go
+++ b/vecengine/forkless_cause_test.go
@@ -12,7 +12,6 @@ package vecengine
 
 import (
 	"fmt"
-	"math/rand"
 	"strconv"
 	"strings"
 	"testing"
@@ -704,7 +703,7 @@ func TestRandomForks(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("Test #%d", i), func(t *testing.T) {
-			r := rand.New(rand.NewSource(int64(i))) // nolint:gosec
+			r := consensustest.NewIntSeededRandGenerator(uint64(i))
 
 			nodes := consensustest.GenNodes(test.nodesNum)
 			cheaters := nodes[:test.cheatersNum]

--- a/vecengine/index_test.go
+++ b/vecengine/index_test.go
@@ -12,7 +12,7 @@ package vecengine
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/0xsoniclabs/consensus/consensus"
@@ -26,6 +26,22 @@ import (
 	"github.com/0xsoniclabs/kvdb/leveldb"
 	"github.com/0xsoniclabs/kvdb/memorydb"
 )
+
+func TestTestera(b *testing.T) {
+	consensustest.FakeHash()
+	consensustest.FakeHash()
+	consensustest.FakeHash()
+	consensustest.FakeHash()
+	consensustest.FakeHash()
+	fmt.Println()
+	for i := range 10 {
+		consensustest.FakeHash(int64(i))
+	}
+	fmt.Println()
+	for i := range 10 {
+		consensustest.FakeHash(int64(i))
+	}
+}
 
 func BenchmarkIndex_Add_MemoryDB(b *testing.B) {
 	dbProducer := func() kvdb.FlushableKVStore {
@@ -104,7 +120,7 @@ func tempLevelDB() (kvdb.Store, error) {
 	cache16mb := func(string) (int, int) {
 		return 16 * opt.MiB, 64
 	}
-	dir, err := ioutil.TempDir("", "bench")
+	dir, err := os.MkdirTemp("", "bench")
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary directory %s: %v", dir, err))
 	}

--- a/vecengine/index_test.go
+++ b/vecengine/index_test.go
@@ -27,22 +27,6 @@ import (
 	"github.com/0xsoniclabs/kvdb/memorydb"
 )
 
-func TestTestera(b *testing.T) {
-	consensustest.FakeHash()
-	consensustest.FakeHash()
-	consensustest.FakeHash()
-	consensustest.FakeHash()
-	consensustest.FakeHash()
-	fmt.Println()
-	for i := range 10 {
-		consensustest.FakeHash(int64(i))
-	}
-	fmt.Println()
-	for i := range 10 {
-		consensustest.FakeHash(int64(i))
-	}
-}
-
 func BenchmarkIndex_Add_MemoryDB(b *testing.B) {
 	dbProducer := func() kvdb.FlushableKVStore {
 		return flushable.Wrap(memorydb.New())

--- a/vecengine/vector_ops.go
+++ b/vecengine/vector_ops.go
@@ -54,7 +54,7 @@ func (b *HighestBeforeSeq) SetForkDetected(i consensus.ValidatorIndex) {
 	b.Set(i, forkDetectedSeq)
 }
 
-func (self *HighestBeforeSeq) CollectFrom(_other HighestBeforeI, num consensus.ValidatorIndex) {
+func (b *HighestBeforeSeq) CollectFrom(_other HighestBeforeI, num consensus.ValidatorIndex) {
 	other := _other.(*HighestBeforeSeq)
 	for branchID := consensus.ValidatorIndex(0); branchID < num; branchID++ {
 		hisSeq := other.Get(branchID)
@@ -62,7 +62,7 @@ func (self *HighestBeforeSeq) CollectFrom(_other HighestBeforeI, num consensus.V
 			// hisSeq doesn't observe anything about this branchID
 			continue
 		}
-		mySeq := self.Get(branchID)
+		mySeq := b.Get(branchID)
 
 		if mySeq.IsForkDetected() {
 			// mySeq observes the maximum already
@@ -70,23 +70,23 @@ func (self *HighestBeforeSeq) CollectFrom(_other HighestBeforeI, num consensus.V
 		}
 		if hisSeq.IsForkDetected() {
 			// set fork detected
-			self.SetForkDetected(branchID)
+			b.SetForkDetected(branchID)
 		} else {
 			if mySeq.Seq == 0 || mySeq.MinSeq > hisSeq.MinSeq {
 				// take hisSeq.MinSeq
 				mySeq.MinSeq = hisSeq.MinSeq
-				self.Set(branchID, mySeq)
+				b.Set(branchID, mySeq)
 			}
 			if mySeq.Seq < hisSeq.Seq {
 				// take hisSeq.Seq
 				mySeq.Seq = hisSeq.Seq
-				self.Set(branchID, mySeq)
+				b.Set(branchID, mySeq)
 			}
 		}
 	}
 }
 
-func (self *HighestBeforeSeq) GatherFrom(to consensus.ValidatorIndex, _other HighestBeforeI, from []consensus.ValidatorIndex) {
+func (b *HighestBeforeSeq) GatherFrom(to consensus.ValidatorIndex, _other HighestBeforeI, from []consensus.ValidatorIndex) {
 	other := _other.(*HighestBeforeSeq)
 	// read all branches to find highest event
 	highestBranchSeq := BranchSeq{}
@@ -100,5 +100,5 @@ func (self *HighestBeforeSeq) GatherFrom(to consensus.ValidatorIndex, _other Hig
 			highestBranchSeq = branch
 		}
 	}
-	self.Set(to, highestBranchSeq)
+	b.Set(to, highestBranchSeq)
 }

--- a/vecflushable/vecflushable_test.go
+++ b/vecflushable/vecflushable_test.go
@@ -12,7 +12,7 @@ package vecflushable
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -229,7 +229,7 @@ func tempLevelDB() (kvdb.Store, error) {
 	cache16mb := func(string) (int, int) {
 		return 16 * opt.MiB, 64
 	}
-	dir, err := ioutil.TempDir("", "bench")
+	dir, err := os.MkdirTemp("", "bench")
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary directory %s: %v", dir, err))
 	}


### PR DESCRIPTION
This PR addresses linting warnings reported by `staticcheck` tool:
- `io/ioutil.TempDir` -> `os.MkdirTemp`. The former got deprecated as it's identical to the latter.
- Made `error` the last returned argument in few instances (convention).
- Removed variables named as common keywords like `self`.
- Swapped from `math/rand` (deprecated) to `math/rand/v2` and `math/crypto`. This one required more adaptation as libraries don't provide a trivial way to create a int seeded generator (has to be done through other more complex randomness sources), as well as a byte generating one (has to be done separately through a specific `ChaCha8` based source).

All unit tests pass, change is integrated through [branch](https://github.com/0xsoniclabs/sonic/tree/dfilip/staticcheck) and all client unit tests pass.