### PR TITLE
chore: git hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,15 @@ deadcode:
 
 .PHONY: lint
 lint: vet staticcheck errorcheck deadcode
+
+# Git Hooks
+
+.PHONY: install-hooks
+install-hooks:
+	@echo "Installing Git hooks..."
+	@mkdir -p .git/hooks
+	@echo '#!/bin/sh\necho "Running pre-commit lint..."\nexec make lint' > .git/hooks/pre-commit
+	@echo '#!/bin/sh\necho "Running pre-push lint..."\nexec make lint' > .git/hooks/pre-push
+	@chmod +x .git/hooks/pre-commit
+	@chmod +x .git/hooks/pre-push
+	@echo "Git hooks installed successfully!"


### PR DESCRIPTION
This PR creates a Makefile command with `install-hooks` that allows installing git hooks so that they are run each time a repository contributor tries to commit a change locally or push it to the remote (this repository).

For now, both `pre-commit` and `pre-push` only run `make lint`, but this is easily extendable.

---

For now, please don't actually run `install-hooks`, and if you do, remove them from your `.git/hooks` directory (`rm -rf .git/hooks/pre-push` and `rm -rf .git/hooks/pre-commit`) - because `make deadcode` still fails for now.

---

Verification:

![image](https://github.com/user-attachments/assets/1288dd88-7fcc-491c-9358-8ff2d5043040)
![image](https://github.com/user-attachments/assets/4520a0fd-4e9e-47cc-ba5e-31191044c05b)

