### PR TITLE
Vecmt hotfix

### DIFF
--- a/consensus/index.go
+++ b/consensus/index.go
@@ -54,6 +54,11 @@ func (e Seq) Bytes() []byte {
 }
 
 // Bytes gets the byte representation of the index.
+func (b BlockID) Bytes() []byte {
+	return byteutils.Uint64ToBigEndian(uint64(b))
+}
+
+// Bytes gets the byte representation of the index.
 func (l Lamport) Bytes() []byte {
 	return byteutils.Uint32ToBigEndian(uint32(l))
 }

--- a/dagindexer/index_test.go
+++ b/dagindexer/index_test.go
@@ -144,7 +144,7 @@ type eventWithCreationTime struct {
 	creationTime Timestamp
 }
 
-func (e *eventWithCreationTime) CreationTime() Timestamp {
+func (e *eventWithCreationTime) CreationTimePortable() Timestamp {
 	return e.creationTime
 }
 

--- a/dagindexer/vector_ops.go
+++ b/dagindexer/vector_ops.go
@@ -5,13 +5,13 @@ import (
 )
 
 type CreationTimer interface {
-	CreationTime() Timestamp
+	CreationTimePortable() Timestamp
 }
 
 func (b *HighestBefore) InitWithEvent(i consensus.ValidatorIndex, e consensus.Event) {
 	b.VSeq.Set(i, BranchSeq{Seq: e.Seq(), MinSeq: e.Seq()})
 	if eCreationTimer, ok := e.(CreationTimer); ok { // Workaround for existing type-unsafe practices.
-		b.VTime.Set(i, eCreationTimer.CreationTime())
+		b.VTime.Set(i, eCreationTimer.CreationTimePortable())
 	}
 }
 


### PR DESCRIPTION
A small error introduced in `vecmt-absorb` has been fixed and everything has been tested properly (with sonic integration).