### PR TITLE
Tests for `vecflushable`

### DIFF
--- a/vecflushable/vecflushable.go
+++ b/vecflushable/vecflushable.go
@@ -129,6 +129,8 @@ func (w *VecFlushable) Close() error {
 	return w.underlying.close()
 }
 
+/* Some methods are not implemented and panic when called */
+
 func (w *VecFlushable) Drop() {
 	panic(errNotImplemented)
 }
@@ -136,8 +138,6 @@ func (w *VecFlushable) Drop() {
 func (w *VecFlushable) AncientDatadir() (string, error) {
 	panic(errNotImplemented)
 }
-
-/* Some methods are not implemented and panic when called */
 
 func (w *VecFlushable) Delete(key []byte) error {
 	panic(errNotImplemented)

--- a/vecflushable/vecflushable_test.go
+++ b/vecflushable/vecflushable_test.go
@@ -242,3 +242,77 @@ func tempLevelDB() (kvdb.Store, error) {
 	ldb, _ := disk.OpenDB("0")
 	return ldb, nil
 }
+
+func TestNilParentWrap(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic, got nil")
+		}
+	}()
+	_ = Wrap(nil, 1000)
+}
+
+func TestNilPut(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	err := vecflushable.Put([]byte("a"), nil)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+
+	err = vecflushable.Put(nil, []byte("a"))
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+func TestHasInModified(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	key := byteutils.Uint64ToBigEndian(uint64(0))
+	val := byteutils.Uint64ToBigEndian(uint64(1))
+
+	if err := vecflushable.Put(key, val); err != nil {
+		t.Error(err)
+	}
+
+	has, err := vecflushable.Has(key)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.True(t, has)
+
+	has, err = vecflushable.Has(byteutils.Uint64ToBigEndian(uint64(2)))
+	if err != nil {
+		t.Error(err)
+	}
+	assert.False(t, has)
+}
+
+func TestHasInBacked(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	key := byteutils.Uint64ToBigEndian(uint64(0))
+	val := byteutils.Uint64ToBigEndian(uint64(1))
+
+	if err := vecflushable.Put(key, val); err != nil {
+		t.Error(err)
+	}
+	// Force contents to underlying
+	vecflushable.Flush()
+
+	has, err := vecflushable.Has(key)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.True(t, has)
+
+	has, err = vecflushable.Has(byteutils.Uint64ToBigEndian(uint64(2)))
+	if err != nil {
+		t.Error(err)
+	}
+	assert.False(t, has)
+}

--- a/vecflushable/vecflushable_test.go
+++ b/vecflushable/vecflushable_test.go
@@ -316,3 +316,180 @@ func TestHasInBacked(t *testing.T) {
 	}
 	assert.False(t, has)
 }
+
+func TestHasClosed(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	key := byteutils.Uint64ToBigEndian(uint64(0))
+	val := byteutils.Uint64ToBigEndian(uint64(1))
+
+	if err := vecflushable.Put(key, val); err != nil {
+		t.Error(err)
+	}
+
+	vecflushable.Close()
+
+	has, err := vecflushable.Has(key)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	assert.False(t, has)
+}
+
+func TestGetClosed(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	key := byteutils.Uint64ToBigEndian(uint64(0))
+	val := byteutils.Uint64ToBigEndian(uint64(1))
+
+	if err := vecflushable.Put(key, val); err != nil {
+		t.Error(err)
+	}
+
+	vecflushable.Close()
+
+	v, err := vecflushable.Get(key)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	assert.Nil(t, v)
+}
+
+func TestFlushClosed(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	key := byteutils.Uint64ToBigEndian(uint64(0))
+	val := byteutils.Uint64ToBigEndian(uint64(1))
+
+	if err := vecflushable.Put(key, val); err != nil {
+		t.Error(err)
+	}
+
+	vecflushable.Close()
+
+	err := vecflushable.Flush()
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+func TestCloseClosed(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	vecflushable.Close()
+
+	err := vecflushable.Close()
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+func TestUnimplementedDrop(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic, got nil")
+		}
+	}()
+
+	vecflushable.Drop()
+
+}
+
+func TestUnimplementedAncientDatadir(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic, got nil")
+		}
+	}()
+
+	vecflushable.AncientDatadir()
+
+}
+
+func TestUnimplementedDelete(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic, got nil")
+		}
+	}()
+
+	vecflushable.Delete([]byte("a"))
+}
+
+func TestUnimplementedGetSnapshot(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic, got nil")
+		}
+	}()
+
+	vecflushable.GetSnapshot()
+}
+
+func TestUnimplementedNewIterator(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic, got nil")
+		}
+	}()
+
+	vecflushable.NewIterator([]byte("a"), []byte("b"))
+}
+
+func TestUnimplementedStat(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic, got nil")
+		}
+	}()
+
+	vecflushable.Stat()
+}
+
+func TestUnimplementedCompact(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic, got nil")
+		}
+	}()
+
+	vecflushable.Compact([]byte("a"), []byte("b"))
+}
+
+func TestUnimplementedNewBatch(t *testing.T) {
+	backupDB, _ := tempLevelDB()
+	vecflushable := Wrap(backupDB, 1000)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic, got nil")
+		}
+	}()
+
+	vecflushable.NewBatch()
+}


### PR DESCRIPTION
Added tests to the `vecflushable` package, offering a total of `93.0%` coverage. Per file, coverage is as follows:
`backed_map.go -> 86.8%`
`vecflushable.go -> 97.9%`

Full report herein:
```
<!DOCTYPE html>
<!-- saved from url=(0099)file:///private/var/folders/s3/801dzbqn1kxcpb344k2229hh0000gn/T/cover2393287031/coverage.html#file0 -->
<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
		
		<title>vecflushable: Go Coverage Report</title>
		<style>
			body {
				background: black;
				color: rgb(80, 80, 80);
			}
			body, pre, #legend span {
				font-family: Menlo, monospace;
				font-weight: bold;
			}
			#topbar {
				background: black;
				position: fixed;
				top: 0; left: 0; right: 0;
				height: 42px;
				border-bottom: 1px solid rgb(80, 80, 80);
			}
			#content {
				margin-top: 50px;
			}
			#nav, #legend {
				float: left;
				margin-left: 10px;
			}
			#legend {
				margin-top: 12px;
			}
			#nav {
				margin-top: 10px;
			}
			#legend span {
				margin: 0 5px;
			}
			.cov0 { color: rgb(192, 0, 0) }
.cov1 { color: rgb(128, 128, 128) }
.cov2 { color: rgb(116, 140, 131) }
.cov3 { color: rgb(104, 152, 134) }
.cov4 { color: rgb(92, 164, 137) }
.cov5 { color: rgb(80, 176, 140) }
.cov6 { color: rgb(68, 188, 143) }
.cov7 { color: rgb(56, 200, 146) }
.cov8 { color: rgb(44, 212, 149) }
.cov9 { color: rgb(32, 224, 152) }
.cov10 { color: rgb(20, 236, 155) }

		</style>
	</head>
	<body>
		<div id="topbar">
			<div id="nav">
				<select id="files">
				
				<option value="file0">github.com/0xsoniclabs/consensus/vecflushable/backed_map.go (86.8%)</option>
				
				<option value="file1">github.com/0xsoniclabs/consensus/vecflushable/vecflushable.go (97.9%)</option>
				
				</select>
			</div>
			<div id="legend">
				<span>not tracked</span>
			
				<span class="cov0">not covered</span>
				<span class="cov8">covered</span>
			
			</div>
		</div>
		<div id="content">
		
		<pre class="file" id="file0" style="display: block;">// Copyright (c) 2025 Fantom Foundation
//
// Use of this software is governed by the Business Source License included
// in the LICENSE file and at fantom.foundation/bsl11.
//
// Change Date: 2028-4-16
//
// On the date above, in accordance with the Business Source License, use of
// this software will be governed by the GNU Lesser General Public License v3.

package vecflushable

import (
        "github.com/ethereum/go-ethereum/common"

        "github.com/0xsoniclabs/kvdb"
)

// TestSizeLimit is used as the limit in unit-test of packages that use vecflushable
const TestSizeLimit = 100000

type backedMap struct {
        cache      map[string][]byte
        backup     kvdb.Store
        memSize    int
        maxMemSize int
        batchSize  int
}

func newBackedMap(backup kvdb.Store, maxMemSize, batchSize int) *backedMap <span class="cov8" title="1">{
        return &amp;backedMap{
                cache:      make(map[string][]byte),
                backup:     backup,
                maxMemSize: maxMemSize,
                batchSize:  batchSize,
        }
}</span>

func (w *backedMap) has(key []byte) (bool, error) <span class="cov8" title="1">{
        if _, ok := w.cache[string(key)]; ok </span><span class="cov8" title="1">{
                return true, nil
        }</span>
        <span class="cov8" title="1">val, err := w.backup.Get(key)
        if err != nil </span><span class="cov0" title="0">{
                return false, err
        }</span>
        <span class="cov8" title="1">return val != nil, nil</span>
}

func (w *backedMap) get(key []byte) ([]byte, error) <span class="cov8" title="1">{
        if val, ok := w.cache[string(key)]; ok </span><span class="cov8" title="1">{
                return common.CopyBytes(val), nil
        }</span>
        <span class="cov8" title="1">return w.backup.Get(key)</span>
}

func (w *backedMap) close() error <span class="cov8" title="1">{
        w.cache = nil
        return w.backup.Close()
}</span>

func (w *backedMap) add(key string, val []byte) <span class="cov8" title="1">{
        lenBefore := len(w.cache)
        w.cache[key] = val
        // TODO it works correctly only if new key/value have the same size (which is practically true currently)
        if len(w.cache) &gt; lenBefore </span><span class="cov8" title="1">{
                w.memSize += mapMemEst(len(key), len(val))
        }</span>
}

// mayUnload evicts and flushes one batch of data
func (w *backedMap) mayUnload() error <span class="cov8" title="1">{
        for w.memSize &gt; w.maxMemSize </span><span class="cov8" title="1">{
                err := w.unload(w.batchSize)
                if err != nil </span><span class="cov0" title="0">{
                        return err
                }</span>
        }

        <span class="cov8" title="1">return nil</span>
}

func (w *backedMap) unload(toUnload int) error <span class="cov8" title="1">{
        batch := w.backup.NewBatch()
        defer batch.Reset()

        for key, val := range w.cache </span><span class="cov8" title="1">{
                err := batch.Put([]byte(key), val)
                if err != nil </span><span class="cov0" title="0">{
                        return err
                }</span>

                <span class="cov8" title="1">delete(w.cache, key)
                rmS := mapMemEst(len(key), len(val))
                if rmS &lt;= w.memSize </span><span class="cov8" title="1">{
                        w.memSize -= rmS
                }</span> else<span class="cov0" title="0"> {
                        w.memSize = 0
                }</span>

                <span class="cov8" title="1">if batch.ValueSize() &gt;= toUnload </span><span class="cov8" title="1">{
                        break</span>
                }
        }

        <span class="cov8" title="1">err := batch.Write()
        if err != nil </span><span class="cov0" title="0">{
                return err
        }</span>

        <span class="cov8" title="1">return nil</span>
}
</pre>
		
		<pre class="file" id="file1" style="display: none">// Copyright (c) 2025 Fantom Foundation
//
// Use of this software is governed by the Business Source License included
// in the LICENSE file and at fantom.foundation/bsl11.
//
// Change Date: 2028-4-16
//
// On the date above, in accordance with the Business Source License, use of
// this software will be governed by the GNU Lesser General Public License v3.

package vecflushable

import (
        "errors"

        "github.com/ethereum/go-ethereum/common"

        "github.com/0xsoniclabs/kvdb"
)

var (
        errClosed         = errors.New("vecflushable - database closed")
        errNotImplemented = errors.New("vecflushable - not implemented")
)

// mapConst is an approximation of the number of extra bytes used by native go
// maps when adding an item to a map.
const mapConst = 100

func mapMemEst(keyS, valueS int) int <span class="cov8" title="1">{
        return mapConst + keyS + valueS
}</span>

// VecFlushable is a fast, append only, Flushable intended for the vecengine.
// It does not implement all of the Flushable interface, just what is needed by
// the vecengine.
type VecFlushable struct {
        modified   map[string][]byte
        underlying backedMap
        memSize    int
}

func wrap(parent kvdb.Store, sizeLimit, batchSize int) *VecFlushable <span class="cov8" title="1">{
        if parent == nil </span><span class="cov8" title="1">{
                panic("nil parent")</span>
        }
        <span class="cov8" title="1">return &amp;VecFlushable{
                modified:   make(map[string][]byte),
                underlying: *newBackedMap(parent, sizeLimit, batchSize),
        }</span>
}

func Wrap(parent kvdb.Store, sizeLimit int) *VecFlushable <span class="cov8" title="1">{
        return wrap(parent, sizeLimit, kvdb.IdealBatchSize)
}</span>

func (w *VecFlushable) clearModified() <span class="cov8" title="1">{
        w.modified = make(map[string][]byte)
        w.memSize = 0
}</span>

func (w *VecFlushable) Has(key []byte) (bool, error) <span class="cov8" title="1">{
        if w.modified == nil </span><span class="cov8" title="1">{
                return false, errClosed
        }</span>
        <span class="cov8" title="1">_, ok := w.modified[string(key)]
        if ok </span><span class="cov8" title="1">{
                return true, nil
        }</span>
        <span class="cov8" title="1">return w.underlying.has(key)</span>
}

func (w *VecFlushable) Get(key []byte) ([]byte, error) <span class="cov8" title="1">{
        if w.modified == nil </span><span class="cov8" title="1">{
                return nil, errClosed
        }</span>
        <span class="cov8" title="1">if val, ok := w.modified[string(key)]; ok </span><span class="cov8" title="1">{
                return common.CopyBytes(val), nil
        }</span>
        <span class="cov8" title="1">return w.underlying.get(key)</span>
}

func (w *VecFlushable) Put(key []byte, value []byte) error <span class="cov8" title="1">{
        if value == nil || key == nil </span><span class="cov8" title="1">{
                return errors.New("vecflushable: key or value is nil")
        }</span>
        <span class="cov8" title="1">w.modified[string(key)] = common.CopyBytes(value)
        w.memSize += mapMemEst(len(key), len(value))
        return nil</span>
}

func (w *VecFlushable) NotFlushedPairs() int <span class="cov8" title="1">{
        return len(w.modified)
}</span>

func (w *VecFlushable) NotFlushedSizeEst() int <span class="cov8" title="1">{
        return w.memSize
}</span>

func (w *VecFlushable) Flush() error <span class="cov8" title="1">{
        if w.modified == nil </span><span class="cov8" title="1">{
                return errClosed
        }</span>

        <span class="cov8" title="1">for key, val := range w.modified </span><span class="cov8" title="1">{
                w.underlying.add(key, val)
        }</span>

        <span class="cov8" title="1">err := w.underlying.mayUnload()
        if err != nil </span><span class="cov0" title="0">{
                return err
        }</span>

        <span class="cov8" title="1">w.clearModified()

        return nil</span>
}

func (w *VecFlushable) DropNotFlushed() <span class="cov8" title="1">{
        w.clearModified()
}</span>

func (w *VecFlushable) Close() error <span class="cov8" title="1">{
        if w.modified == nil </span><span class="cov8" title="1">{
                return errClosed
        }</span>
        <span class="cov8" title="1">w.DropNotFlushed()
        w.modified = nil
        return w.underlying.close()</span>
}

/* Some methods are not implemented and panic when called */

func (w *VecFlushable) Drop() <span class="cov8" title="1">{
        panic(errNotImplemented)</span>
}

func (w *VecFlushable) AncientDatadir() (string, error) <span class="cov8" title="1">{
        panic(errNotImplemented)</span>
}

func (w *VecFlushable) Delete(key []byte) error <span class="cov8" title="1">{
        panic(errNotImplemented)</span>
}

func (w *VecFlushable) GetSnapshot() (kvdb.Snapshot, error) <span class="cov8" title="1">{
        panic(errNotImplemented)</span>
}

func (w *VecFlushable) NewIterator(prefix []byte, start []byte) kvdb.Iterator <span class="cov8" title="1">{
        panic(errNotImplemented)</span>
}

func (w *VecFlushable) Stat() (string, error) <span class="cov8" title="1">{
        panic(errNotImplemented)</span>
}

func (w *VecFlushable) Compact(start []byte, limit []byte) error <span class="cov8" title="1">{
        panic(errNotImplemented)</span>
}

func (w *VecFlushable) NewBatch() kvdb.Batch <span class="cov8" title="1">{
        panic(errNotImplemented)</span>
}
</pre>
		
		</div>
	
	<script>
	(function() {
		var files = document.getElementById('files');
		var visible;
		files.addEventListener('change', onChange, false);
		function select(part) {
			if (visible)
				visible.style.display = 'none';
			visible = document.getElementById(part);
			if (!visible)
				return;
			files.value = part;
			visible.style.display = 'block';
			location.hash = part;
		}
		function onChange() {
			select(files.value);
			window.scrollTo(0, 0);
		}
		if (location.hash != "") {
			select(location.hash.substr(1));
		}
		if (!visible) {
			select("file0");
		}
	})();
	</script>

</body></html>
```