### PR TITLE
Add linters to CI tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+version: "2"
+linters:
+  settings:
+    staticcheck:
+      initialisms: []
+      dot-import-whitelist: []
+      http-status-code-whitelist: []
+      checks:
+        - all
+        # default ignored checks
+        - "-SA9003" # Empty body in an if or else branch.
+        - "-ST1000" # Invalid regular expression.
+        - "-ST1003" # Unsupported argument to functions in 'encoding/binary'.
+        - "-ST1016" # Trapping a signal that cannot be trapped.
+        - "-ST1020" # Using an invalid host:port pair with a 'net.Listen'-related function.
+        - "-ST1021" # Using 'bytes.Equal' to compare two 'net.IP'.
+        - "-ST1022" #
+        - "-ST1023" # Modifying the buffer in an 'io.Writer' implementation.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,11 @@ pipeline {
             }
         }
 
+        stage('Run linters') {
+            steps {
+                sh 'golangci-lint run ./...'
+            }
+        }
         stage('Run tests') {
             steps {
                 sh 'make test'


### PR DESCRIPTION
Add linters to Jenkins files. Linters use default configurations which can be found in https://golangci-lint.run/usage/linters/

Enabled linters: `errcheck`, `go vet`, `ineffassign`, `staticcheck`, `unused`