### PR TITLE
chore: make certified state DB key consistent

### DIFF
--- a/consensus/consensusstore/genesis.go
+++ b/consensus/consensusstore/genesis.go
@@ -23,7 +23,7 @@ type Genesis struct {
 }
 
 func (s *Store) ApplyGenesis(g *Genesis) error {
-	if ok, _ := s.table.LastCertifiedState.Has([]byte(dsKey)); ok {
+	if ok, _ := s.table.LastCertifiedState.Has([]byte(csKey)); ok {
 		return fmt.Errorf("genesis already applied")
 	}
 	return s.SwitchGenesis(g)

--- a/consensus/consensusstore/genesis_test.go
+++ b/consensus/consensusstore/genesis_test.go
@@ -25,7 +25,7 @@ func TestGenesis_Sucess(t *testing.T) {
 	if want, got := epochState.Validators.Get(1), validators.Get(1); want != got {
 		t.Fatalf("expected set validator weight: %d, got: %d", want, got)
 	}
-	lastCertifiedState, exists := store.get(store.table.LastCertifiedState, []byte(dsKey), &LastCertifiedState{}).(*LastCertifiedState)
+	lastCertifiedState, exists := store.get(store.table.LastCertifiedState, []byte(csKey), &LastCertifiedState{}).(*LastCertifiedState)
 	if !exists {
 		t.Fatal("last certified state not set")
 	}
@@ -43,7 +43,7 @@ func TestGenesis_Fail(t *testing.T) {
 	}
 	validatorBuilder := consensus.NewValidatorsBuilder()
 	validatorBuilder.Set(1, 10)
-	err := store.table.LastCertifiedState.Put([]byte(dsKey), []byte{})
+	err := store.table.LastCertifiedState.Put([]byte(csKey), []byte{})
 	if err != nil {
 		t.Fatalf("failed to set up prerequisite state (Put LastCertifiedState): %v", err)
 	}

--- a/consensus/consensusstore/store.go
+++ b/consensus/consensusstore/store.go
@@ -30,7 +30,7 @@ type Store struct {
 
 	MainDB kvdb.Store
 	table  struct {
-		LastCertifiedState kvdb.Store `table:"c"`
+		LastCertifiedState kvdb.Store `table:"d"` // certified state key ("d" for legacy reasons for "decided")
 		EpochState         kvdb.Store `table:"e"`
 	}
 

--- a/consensus/consensusstore/store_last_certified_state.go
+++ b/consensus/consensusstore/store_last_certified_state.go
@@ -12,7 +12,8 @@ package consensusstore
 
 import "github.com/0xsoniclabs/consensus/consensus"
 
-const dsKey = "d"
+// certified state key ("d" for legacy reasons for "decided")
+const csKey = "d"
 
 // LastCertifiedState is for persistent storing.
 type LastCertifiedState struct {
@@ -25,7 +26,7 @@ type LastCertifiedState struct {
 func (s *Store) SetLastCertifiedState(v *LastCertifiedState) {
 	s.cache.LastCertifiedState = v
 
-	s.set(s.table.LastCertifiedState, []byte(dsKey), v)
+	s.set(s.table.LastCertifiedState, []byte(csKey), v)
 }
 
 // GetLastCertifiedState returns stored LastCertifiedState.
@@ -35,7 +36,7 @@ func (s *Store) GetLastCertifiedState() *LastCertifiedState {
 		return s.cache.LastCertifiedState
 	}
 
-	w, exists := s.get(s.table.LastCertifiedState, []byte(dsKey), &LastCertifiedState{}).(*LastCertifiedState)
+	w, exists := s.get(s.table.LastCertifiedState, []byte(csKey), &LastCertifiedState{}).(*LastCertifiedState)
 	if !exists {
 		s.crit(ErrNoGenesis)
 	}


### PR DESCRIPTION
This PR addresses https://github.com/orgs/0xsoniclabs/projects/1/views/1?pane=issue&itemId=111912358&issue=0xsoniclabs%7Cconsensus%7C145

- After the nomenclature change of "decided" to "certified" - we have updated the term "decided state" to be "certified state".
- We used a database key of `d` and `c` for `LastCertifiedState`, which was a mismatch.

This PR adopts the usage of `d` to not break legacy tests or existing infrastructure which may rely on the database but renames the variable `dsKey` to `csKey` with a comment to explain the variable name.

---

Verification:

![image](https://github.com/user-attachments/assets/8d52f2fc-93e4-429d-89be-201510cd9593)
![image](https://github.com/user-attachments/assets/1e2f142a-ccb0-42ae-82a7-e842a62cb7ab)
