### PR TITLE
Fix for the issue with interrupts failing

### DIFF
--- a/consensus/vecflushable/backed_map.go
+++ b/consensus/vecflushable/backed_map.go
@@ -55,8 +55,23 @@ func (w *backedMap) get(key []byte) ([]byte, error) {
 }
 
 func (w *backedMap) close() error {
+	batch := w.backup.NewBatch()
+	defer batch.Reset()
+
+	for key, val := range w.cache {
+		err := batch.Put([]byte(key), val)
+		if err != nil {
+			return err
+		}
+	}
+	err := batch.Write()
+	if err != nil {
+		return err
+	}
+
 	w.cache = nil
-	return w.backup.Close()
+	// backing kvdb.Store not closed here intentionally (is a table)
+	return nil
 }
 
 func (w *backedMap) add(key string, val []byte) {


### PR DESCRIPTION
We recently discovered an issue where doing a Ctrl+C interrupt on an event import left the database in a state where it could not continue the import process any further. We found that it was linked to the merging of `vecfc` and `vecmt` into `dagindexer`. Namely, `sonic` used another implementation of `vecflushable` which was "lost" in the merging. This version is more suitable and seemingly better than the one present in `consensus` currently, as it addresses the issue at hand.
This recent change causes the issue to stop appearing and imports can be interrupted and resumed normally.