### PR TITLE
Remove Strongly Reach cache

### DIFF
--- a/consensus/dagindexer/index.go
+++ b/consensus/dagindexer/index.go
@@ -33,7 +33,6 @@ type Timestamp = uint64
 type IndexCacheConfig struct {
 	HighestBeforeTimeSize uint
 	DBCache               int
-	StronglyReachPairs    int
 	HighestBeforeSeqSize  uint
 	LowestAfterSeqSize    uint
 }
@@ -64,7 +63,6 @@ type Index struct {
 
 	cache struct {
 		HighestBeforeTime *wlru.Cache
-		StronglyReach     *simplewlru.Cache
 		HighestBeforeSeq  *simplewlru.Cache
 		LowestAfterSeq    *simplewlru.Cache
 	}
@@ -78,7 +76,6 @@ func DefaultConfig(scale cachescale.Func) IndexConfig {
 		Caches: IndexCacheConfig{
 			HighestBeforeTimeSize: scale.U(160 * 1024),
 			DBCache:               scale.I(10 * opt.MiB),
-			StronglyReachPairs:    scale.I(20000),
 			HighestBeforeSeqSize:  scale.U(160 * 1024),
 			LowestAfterSeqSize:    scale.U(160 * 1024),
 		},
@@ -91,7 +88,6 @@ func LiteConfig() IndexConfig {
 	return IndexConfig{
 		Caches: IndexCacheConfig{
 			HighestBeforeTimeSize: 4 * 1024,
-			StronglyReachPairs:    scale.I(20000),
 			HighestBeforeSeqSize:  scale.U(160 * 1024),
 			LowestAfterSeqSize:    scale.U(160 * 1024),
 		},
@@ -129,7 +125,6 @@ func (vi *Index) Flush() {
 
 func (vi *Index) initCaches() {
 	vi.cache.HighestBeforeTime, _ = wlru.New(vi.cfg.Caches.HighestBeforeTimeSize, int(vi.cfg.Caches.HighestBeforeTimeSize))
-	vi.cache.StronglyReach, _ = simplewlru.New(uint(vi.cfg.Caches.StronglyReachPairs), vi.cfg.Caches.StronglyReachPairs)
 	vi.cache.HighestBeforeSeq, _ = simplewlru.New(vi.cfg.Caches.HighestBeforeSeqSize, int(vi.cfg.Caches.HighestBeforeSeqSize))
 	vi.cache.LowestAfterSeq, _ = simplewlru.New(vi.cfg.Caches.LowestAfterSeqSize, int(vi.cfg.Caches.HighestBeforeSeqSize))
 }
@@ -155,7 +150,6 @@ func (vi *Index) Reset(validators *consensus.Validators, db kvdb.FlushableKVStor
 	vi.validatorIdxs = validators.Idxs()
 	vi.DropNotFlushed()
 	table.MigrateTables(&vi.table, vi.vecDb)
-	vi.cache.StronglyReach.Purge()
 	vi.OnDropNotFlushed()
 }
 

--- a/consensus/dagindexer/strongly_reach.go
+++ b/consensus/dagindexer/strongly_reach.go
@@ -35,18 +35,7 @@ type kv struct {
 // This great property is the reason why this function exists,
 // providing the base for the BFT algorithm.
 func (vi *Index) StronglyReach(aID, bID consensus.EventHash) bool {
-	if res, ok := vi.cache.StronglyReach.Get(kv{aID, bID}); ok {
-		return res.(bool)
-	}
-
 	vi.InitBranchesInfo()
-	res := vi.stronglyReaches(aID, bID)
-
-	vi.cache.StronglyReach.Add(kv{aID, bID}, res, 1)
-	return res
-}
-
-func (vi *Index) stronglyReaches(aID, bID consensus.EventHash) bool {
 	// Get events by hash
 	aFull := vi.GetHighestBefore(aID)
 	if aFull == nil {

--- a/consensus/dagindexer/strongly_reach_test.go
+++ b/consensus/dagindexer/strongly_reach_test.go
@@ -782,7 +782,6 @@ func TestRandomEquivocations(t *testing.T) {
 					assertar.NoError(vi.Add(a))
 				}
 
-				vi.cache.StronglyReach.Purge() // disable cache
 				for _, a := range processedArr {
 					for _, b := range processedArr {
 						pair := kv{


### PR DESCRIPTION
This PR removes cache dedicated for Strongly Reach operation between two events. As of #24, the frame construction is reduced to a single `stronglyReachableByQuorum` operation and the reprocessing of roots can no longer happen. This means that the necessity of caching the strongly reach operation is greatly reduced, and only possible scenario where it could be helpful is when frame construction and election call the StronglyReach operation back-to-back, with same arguments. This can be eliminated with a simple memoization in future work.

Testing done:
All unit tests pass
Client build with the PR branch passes epochs [1, 1100] and [6720, 6970] and produces a correct head.