### PR TITLE
Basic Strongly Reach memoization

### DIFF
--- a/consensus/consensusengine/db_election_driver.go
+++ b/consensus/consensusengine/db_election_driver.go
@@ -122,6 +122,7 @@ func GetEpochRange(conn *sql.DB) (consensus.Epoch, consensus.Epoch, error) {
 
 func ingestEvent(testLachesis *CoreLachesis, eventStore *consensustest.TestEventSource, event *dbEvent) error {
 	testEvent := &consensustest.TestEvent{}
+	testEvent.SetFrame(event.frame)
 	testEvent.SetSeq(event.seq)
 	testEvent.SetCreator(event.validatorId)
 	testEvent.SetParents(event.parents)
@@ -130,28 +131,18 @@ func ingestEvent(testLachesis *CoreLachesis, eventStore *consensustest.TestEvent
 	testEvent.SetID([24]byte(event.hash[8:]))
 	eventStore.SetEvent(testEvent)
 
-	return processLocalEvent(testLachesis, testEvent, event.frame)
+	return processLocalEvent(testLachesis, testEvent)
 }
 
 // processLocalEvent simulates a flattened (without redudantant indexing and frame (re)calculations)
 // event lifecycle in local computation intensive consensus components - DAG indexing, frame calculation, election
 // Conditions and order in which the components are invoked are identical to production Consensus behaviour
-func processLocalEvent(testLachesis *CoreLachesis, event *consensustest.TestEvent, targetFrame consensus.Frame) error {
+func processLocalEvent(testLachesis *CoreLachesis, event *consensustest.TestEvent) error {
 	if err := testLachesis.DagIndexer.Add(event); err != nil {
 		return fmt.Errorf("error wihile indexing event: [validator: %d, seq: %d], err: %v", event.Creator(), event.Seq(), err)
 	}
-	if err := testLachesis.Lachesis.Build(event); err != nil {
-		return fmt.Errorf("error wihile building event: [validator: %d, seq: %d], err: %v", event.Creator(), event.Seq(), err)
-	}
-	if targetFrame != event.Frame() {
-		return fmt.Errorf("incorrect frame recalculated for event: [validator: %d, seq: %d], expected: %d, got: %d", event.Creator(), event.Seq(), targetFrame, event.Frame())
-	}
-	selfParentFrame := testLachesis.getSelfParentFrame(event)
-	if selfParentFrame != event.Frame() {
-		testLachesis.store.AddBase(event)
-		if _, err := testLachesis.runElectionOnBase(event.Frame(), event.Creator(), event.ID()); err != nil {
-			return fmt.Errorf("error wihile processing event: [validator: %d, seq: %d], err: %v", event.Creator(), event.Seq(), err)
-		}
+	if err := testLachesis.Lachesis.Process(event); err != nil {
+		return fmt.Errorf("error while processing event: [validator: %d, seq: %d], err: %v", event.Creator(), event.Seq(), err)
 	}
 
 	return nil

--- a/consensus/consensusengine/election.go
+++ b/consensus/consensusengine/election.go
@@ -74,6 +74,7 @@ func (el *election) VoteAndAggregate(
 	frame consensus.Frame,
 	validatorId consensus.ValidatorID,
 	baseHash consensus.EventHash,
+	stronglyReachableBases []*consensusstore.BaseDescriptor,
 ) ([]*leaderCertification, error) {
 	if el.isAlreadyCertified(frame) {
 		return []*leaderCertification{}, nil
@@ -87,10 +88,9 @@ func (el *election) VoteAndAggregate(
 	aggregationMatrix := make([]int32, (frame-el.frameToDeliver-1)*el.validatorCount, (frame-el.frameToDeliver)*el.validatorCount)
 	directVoteVector := initInt32WithConst(-1, int(el.validatorCount))
 
-	reachableBases := el.reachableBases(baseHash, frame-1)
 	reachableBasesWeight := int32(0)
 
-	for _, reachableBase := range reachableBases {
+	for _, reachableBase := range stronglyReachableBases {
 		validatorIdx := el.validatorIDMap[reachableBase.ValidatorID]
 		directVoteVector[validatorIdx] = 1
 		reachableBasesWeight += int32(el.validators.GetWeightByIdx(validatorIdx))
@@ -177,17 +177,6 @@ func (el *election) elect(frame consensus.Frame, validatorCandidate consensus.Va
 	}
 
 	return leaderHash
-}
-
-func (el *election) reachableBases(base consensus.EventHash, frame consensus.Frame) []consensusstore.BaseDescriptor {
-	reachableBases := make([]consensusstore.BaseDescriptor, 0, el.validators.Len())
-	frameBases := el.getFrameBases(frame)
-	for _, frameBase := range frameBases {
-		if el.stronglyReaches(base, frameBase.BaseHash) {
-			reachableBases = append(reachableBases, frameBase)
-		}
-	}
-	return reachableBases
 }
 
 func (el *election) prepareNewElectorBase(frame consensus.Frame, validatorIdx consensus.ValidatorIndex, base consensus.EventHash) {

--- a/consensus/consensusengine/election_test.go
+++ b/consensus/consensusengine/election_test.go
@@ -285,7 +285,14 @@ func testVoteAndAggregate(
 		if !ok {
 			t.Fatal("inconsistent vertices")
 		}
-		leaders, err := election.VoteAndAggregate(baseSlot.frame, baseSlot.validatorID, baseHash)
+		frameBases := election.getFrameBases(baseSlot.frame - 1)
+		stronglyReachableBases := make([]*consensusstore.BaseDescriptor, 0, len(frameBases)/2)
+		for idx, reachableBase := range frameBases {
+			if stronglyReachFn(baseHash, reachableBase.BaseHash) {
+				stronglyReachableBases = append(stronglyReachableBases, &frameBases[idx])
+			}
+		}
+		leaders, err := election.VoteAndAggregate(baseSlot.frame, baseSlot.validatorID, baseHash, stronglyReachableBases)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/consensus/consensusengine/event_processing.go
+++ b/consensus/consensusengine/event_processing.go
@@ -51,7 +51,7 @@ func (p *Orderer) Process(e consensus.Event) (err error) {
 		return nil
 	}
 	p.store.AddBase(e)
-	// Gather strongly reachable bases if they havn't been memoized by the frame construction
+	// Gather strongly reachable bases if they haven't been memoized by the frame construction
 	if stronglyReachableBases == nil {
 		stronglyReachableBases = p.stronglyReachableBases(e.ID(), e.Frame()-1)
 	}

--- a/consensus/consensusengine/event_processing.go
+++ b/consensus/consensusengine/event_processing.go
@@ -65,7 +65,6 @@ func (p *Orderer) Process(e consensus.Event) (err error) {
 
 // runElectionOnBase runs Leader election for the base and triggers block closure callbacks if election was certified
 func (p *Orderer) runElectionOnBase(frame consensus.Frame, validatorID consensus.ValidatorID, baseHash consensus.EventHash, stronglyReachableBases []*consensusstore.BaseDescriptor) (bool, error) {
-	// func (p *Orderer) runElectionOnBase(frame consensus.Frame, validatorID consensus.ValidatorID, baseHash consensus.EventHash) (bool, error) {
 	certifications, err := p.election.VoteAndAggregate(frame, validatorID, baseHash, stronglyReachableBases)
 	if err != nil {
 		return false, err
@@ -115,8 +114,8 @@ func (p *Orderer) stronglyReachableByQuorum(e consensus.Event, f consensus.Frame
 	return reachableCounter.HasQuorum()
 }
 
-// stronglyReachableByQuorumMemoize extends the standard stronglyReachableByQuorum by memoizing the strongly reachable bases
-// performs worse than its vanilla counterpart as it iterates over all the bases even when quorum is reached mid-iteration.
+// stronglyReachableByQuorumMemoize extends the standard stronglyReachableByQuorum by memoizing the strongly reachable bases.
+// It performs worse than its vanilla counterpart as it checks the SR relation for all the bases - even when quorum is reached mid-iteration.
 func (p *Orderer) stronglyReachableByQuorumMemoize(e consensus.Event, f consensus.Frame) (bool, []*consensusstore.BaseDescriptor) {
 	reachableCounter := p.store.GetValidators().NewCounter()
 	frameBases := p.store.GetFrameBases(f)
@@ -155,13 +154,13 @@ func (p *Orderer) constructEventFrame(e consensus.Event) (selfParentFrame, frame
 	// Memoize the strongly reachable calculations only if they can be reused by the election algorithm:
 	// The event comes in with an already assigned frame by its creator, where providing an incorrect frame invalidates the event.
 	// To this end, the algorithm utilizes the provided frame to predict whether the SR should be memoized and can be
-	// reused by the upcoming election algorithm. The calculations can only be reused if the events frame ends up being greater
-	// max frame of its parents.
-	if e.Frame() == frame {
+	// reused by the upcoming election algorithm. The calculations can only be reused if the events frame ends up being one
+	// above the maximum frame of its parents.
+	if e.Frame() == frame+1 {
+		reachable, memoizedDescriptors = p.stronglyReachableByQuorumMemoize(e, frame)
+	} else {
 		reachable = p.stronglyReachableByQuorum(e, frame)
 		memoizedDescriptors = nil
-	} else {
-		reachable, memoizedDescriptors = p.stronglyReachableByQuorumMemoize(e, frame)
 	}
 	if reachable {
 		frame++

--- a/consensus/consensusengine/event_processing.go
+++ b/consensus/consensusengine/event_processing.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/0xsoniclabs/consensus/consensus"
+	"github.com/0xsoniclabs/consensus/consensus/consensusstore"
 )
 
 var (
@@ -30,8 +31,7 @@ func (p *Orderer) Build(e consensus.MutableEvent) error {
 	if !p.store.GetValidators().Exists(e.Creator()) {
 		p.crit(errors.New("event wasn't created by an existing validator"))
 	}
-
-	_, frame := p.calcFrameIdx(e)
+	_, frame, _ := p.constructEventFrame(e)
 	e.SetFrame(frame)
 
 	return nil
@@ -42,15 +42,20 @@ func (p *Orderer) Build(e consensus.MutableEvent) error {
 // All the event checkers must be launched.
 // Process is not safe for concurrent use.
 func (p *Orderer) Process(e consensus.Event) (err error) {
-	selfParentFrame, err := p.checkAndSaveEvent(e)
-	if err != nil {
-		return err
+	// Verify event's frame and proceed with election if it is a base
+	selfParentFrame, frameIdx, stronglyReachableBases := p.constructEventFrame(e)
+	if !p.config.SuppressFramePanic && e.Frame() != frameIdx {
+		return ErrWrongFrame
 	}
-
 	if selfParentFrame == e.Frame() {
 		return nil
 	}
-	if _, err := p.runElectionOnBase(e.Frame(), e.Creator(), e.ID()); err != nil {
+	p.store.AddBase(e)
+	// Gather strongly reachable bases if they havn't been memoized by the frame construction
+	if stronglyReachableBases == nil {
+		stronglyReachableBases = p.stronglyReachableBases(e.ID(), e.Frame()-1)
+	}
+	if _, err := p.runElectionOnBase(e.Frame(), e.Creator(), e.ID(), stronglyReachableBases); err != nil {
 		// election doesn't fail under normal circumstances
 		// storage is in an inconsistent state
 		p.crit(err)
@@ -58,23 +63,10 @@ func (p *Orderer) Process(e consensus.Event) (err error) {
 	return err
 }
 
-// checkAndSaveEvent checks consensus-related fields: Frame, IsBase
-func (p *Orderer) checkAndSaveEvent(e consensus.Event) (consensus.Frame, error) {
-	// check frame & isBase
-	selfParentFrame, frameIdx := p.calcFrameIdx(e)
-	if !p.config.SuppressFramePanic && e.Frame() != frameIdx {
-		return 0, ErrWrongFrame
-	}
-
-	if selfParentFrame != frameIdx {
-		p.store.AddBase(e)
-	}
-	return selfParentFrame, nil
-}
-
 // runElectionOnBase runs Leader election for the base and triggers block closure callbacks if election was certified
-func (p *Orderer) runElectionOnBase(frame consensus.Frame, validatorID consensus.ValidatorID, baseHash consensus.EventHash) (bool, error) {
-	certifications, err := p.election.VoteAndAggregate(frame, validatorID, baseHash)
+func (p *Orderer) runElectionOnBase(frame consensus.Frame, validatorID consensus.ValidatorID, baseHash consensus.EventHash, stronglyReachableBases []*consensusstore.BaseDescriptor) (bool, error) {
+	// func (p *Orderer) runElectionOnBase(frame consensus.Frame, validatorID consensus.ValidatorID, baseHash consensus.EventHash) (bool, error) {
+	certifications, err := p.election.VoteAndAggregate(frame, validatorID, baseHash, stronglyReachableBases)
 	if err != nil {
 		return false, err
 	}
@@ -97,7 +89,7 @@ func (p *Orderer) bootstrapElection() error {
 			break
 		}
 		for _, base := range frameBases {
-			sealed, err := p.runElectionOnBase(frame, base.ValidatorID, base.BaseHash)
+			sealed, err := p.runElectionOnBase(frame, base.ValidatorID, base.BaseHash, p.stronglyReachableBases(base.BaseHash, frame-1))
 			if err != nil {
 				return err
 			}
@@ -112,10 +104,9 @@ func (p *Orderer) bootstrapElection() error {
 // stronglyReachableByQuorum returns true if event is strongly reachable by 2/3W bases on specified frame
 func (p *Orderer) stronglyReachableByQuorum(e consensus.Event, f consensus.Frame) bool {
 	reachableCounter := p.store.GetValidators().NewCounter()
-	// check "observing" prev bases only if called by creator, or if creator has marked that event as base
-	for _, it := range p.store.GetFrameBases(f) {
-		if p.dagIndex.StronglyReach(e.ID(), it.BaseHash) {
-			reachableCounter.CountVoteByID(it.ValidatorID)
+	for _, baseDescriptor := range p.store.GetFrameBases(f) {
+		if p.dagIndex.StronglyReach(e.ID(), baseDescriptor.BaseHash) {
+			reachableCounter.CountVoteByID(baseDescriptor.ValidatorID)
 		}
 		if reachableCounter.HasQuorum() {
 			break
@@ -124,26 +115,56 @@ func (p *Orderer) stronglyReachableByQuorum(e consensus.Event, f consensus.Frame
 	return reachableCounter.HasQuorum()
 }
 
+// stronglyReachableByQuorumMemoize extends the standard stronglyReachableByQuorum by memoizing the strongly reachable bases
+// performs worse than its vanilla counterpart as it iterates over all the bases even when quorum is reached mid-iteration.
+func (p *Orderer) stronglyReachableByQuorumMemoize(e consensus.Event, f consensus.Frame) (bool, []*consensusstore.BaseDescriptor) {
+	reachableCounter := p.store.GetValidators().NewCounter()
+	frameBases := p.store.GetFrameBases(f)
+	memoizedDescriptors := make([]*consensusstore.BaseDescriptor, 0)
+	for idx, baseDescriptor := range frameBases {
+		if p.dagIndex.StronglyReach(e.ID(), baseDescriptor.BaseHash) {
+			reachableCounter.CountVoteByID(baseDescriptor.ValidatorID)
+			memoizedDescriptors = append(memoizedDescriptors, &frameBases[idx])
+		}
+	}
+	return reachableCounter.HasQuorum(), memoizedDescriptors
+}
+
+func (p *Orderer) stronglyReachableBases(eventHash consensus.EventHash, f consensus.Frame) []*consensusstore.BaseDescriptor {
+	frameBases := p.store.GetFrameBases(f)
+	memoizedDescriptors := make([]*consensusstore.BaseDescriptor, 0)
+	for idx, baseDescriptor := range p.store.GetFrameBases(f) {
+		if p.dagIndex.StronglyReach(eventHash, baseDescriptor.BaseHash) {
+			memoizedDescriptors = append(memoizedDescriptors, &frameBases[idx])
+		}
+	}
+	return memoizedDescriptors
+}
+
 // calcFrameIdx is not safe for concurrent use.
-func (p *Orderer) calcFrameIdx(e consensus.Event) (selfParentFrame, frame consensus.Frame) {
+func (p *Orderer) constructEventFrame(e consensus.Event) (selfParentFrame, frame consensus.Frame, memoizedDescriptors []*consensusstore.BaseDescriptor) {
 	if e.SelfParent() == nil {
-		return 0, 1
+		return 0, 1, []*consensusstore.BaseDescriptor{}
 	}
 	selfParentFrame = p.Input.GetEvent(*e.SelfParent()).Frame()
 	frame = selfParentFrame
 	for _, parent := range e.Parents() {
 		frame = max(frame, p.Input.GetEvent(parent).Frame())
 	}
-
-	if p.stronglyReachableByQuorum(e, frame) {
+	var reachable bool
+	// Memoize the strongly reachable calculations only if they can be reused by the election algorithm:
+	// The event comes in with an already assigned frame by its creator, where providing an incorrect frame invalidates the event.
+	// To this end, the algorithm utilizes the provided frame to predict whether the SR should be memoized and can be
+	// reused by the upcoming election algorithm. The calculations can only be reused if the events frame ends up being greater
+	// max frame of its parents.
+	if e.Frame() == frame {
+		reachable = p.stronglyReachableByQuorum(e, frame)
+		memoizedDescriptors = nil
+	} else {
+		reachable, memoizedDescriptors = p.stronglyReachableByQuorumMemoize(e, frame)
+	}
+	if reachable {
 		frame++
 	}
-	return selfParentFrame, frame
-}
-
-func (p *Orderer) getSelfParentFrame(e consensus.Event) consensus.Frame {
-	if e.SelfParent() == nil {
-		return 0
-	}
-	return p.Input.GetEvent(*e.SelfParent()).Frame()
+	return selfParentFrame, frame, memoizedDescriptors
 }


### PR DESCRIPTION
This PR introduces a basic memoization of strongly reach operations between the frame construction and election.

Since #24, the frame construction process invokes the costly Strongly Reach only on a single frame bases set, which can be reused by election in scenarios where this frame matches the frame on which the event will cast the votes. This information can be extracted in advance, by peeking at the already provided frame field of the event. Falsely setting this field invalidates the event altogether thus relying on it is always safe - if the frame was set correctly, the event will proceed to the election with correctly memoized SR relations, while on its falsification, the event won't even make it to election and will be discarded.

In scenarios where the frames of interest don't match, the correct SR relations will simply be calculated from scratch for the election algorithm.

Together with #151, this PR completely eliminates any need for calling the Strongly Reach with same arguments more than once in Consensus' lifetime.

Testing done:
All unit tests pass
Client build with the PR branch passes epochs [1, 1100] and [6720, 6970] and produces a correct head.
