### PR TITLE
Anti quorum and early fail quorum decisions

### DIFF
--- a/consensus/consensusengine/event_processing.go
+++ b/consensus/consensusengine/event_processing.go
@@ -11,6 +11,8 @@
 package consensusengine
 
 import (
+	"slices"
+
 	"github.com/pkg/errors"
 
 	"github.com/0xsoniclabs/consensus/consensus"
@@ -102,16 +104,24 @@ func (p *Orderer) bootstrapElection() error {
 
 // stronglyReachableByQuorum returns true if event is strongly reachable by 2/3W bases on specified frame
 func (p *Orderer) stronglyReachableByQuorum(e consensus.Event, f consensus.Frame) bool {
-	reachableCounter := p.store.GetValidators().NewCounter()
-	for _, baseDescriptor := range p.store.GetFrameBases(f) {
+	validators := p.store.GetValidators()
+	reachableCounter := validators.NewCounter()
+	frameBases := p.store.GetFrameBases(f)
+	// Traverse the frame bases in a descending stake of their respective validators to reach the quorum/AntiQuorum with the least amount of StronglyReach calls
+	slices.SortFunc(frameBases, func(a, b consensusstore.BaseDescriptor) int {
+		return int(validators.GetWeightByIdx(validators.GetIdx(b.ValidatorID))) - int(validators.GetWeightByIdx(validators.GetIdx(a.ValidatorID)))
+	})
+	for _, baseDescriptor := range frameBases {
 		if p.dagIndex.StronglyReach(e.ID(), baseDescriptor.BaseHash) {
 			reachableCounter.CountVoteByID(baseDescriptor.ValidatorID)
+		} else {
+			reachableCounter.CountAntiVoteByID(baseDescriptor.ValidatorID)
 		}
-		if reachableCounter.HasQuorum() {
+		if reachableCounter.AntiQuorumReached() || reachableCounter.QuorumReached() {
 			break
 		}
 	}
-	return reachableCounter.HasQuorum()
+	return reachableCounter.QuorumReached()
 }
 
 // stronglyReachableByQuorumMemoize extends the standard stronglyReachableByQuorum by memoizing the strongly reachable bases.
@@ -126,7 +136,7 @@ func (p *Orderer) stronglyReachableByQuorumMemoize(e consensus.Event, f consensu
 			memoizedDescriptors = append(memoizedDescriptors, &frameBases[idx])
 		}
 	}
-	return reachableCounter.HasQuorum(), memoizedDescriptors
+	return reachableCounter.QuorumReached(), memoizedDescriptors
 }
 
 func (p *Orderer) stronglyReachableBases(eventHash consensus.EventHash, f consensus.Frame) []*consensusstore.BaseDescriptor {

--- a/consensus/consensusengine/event_processing.go
+++ b/consensus/consensusengine/event_processing.go
@@ -107,7 +107,7 @@ func (p *Orderer) stronglyReachableByQuorum(e consensus.Event, f consensus.Frame
 	validators := p.store.GetValidators()
 	reachableCounter := validators.NewCounter()
 	frameBases := p.store.GetFrameBases(f)
-	// Traverse the frame bases in a descending stake of their respective validators to reach the quorum/AntiQuorum with the least amount of StronglyReach calls
+	// Traverse the frame bases in a descending order of their respective validator stake to reach the quorum/AntiQuorum with the least amount of StronglyReach calls
 	slices.SortFunc(frameBases, func(a, b consensusstore.BaseDescriptor) int {
 		return int(validators.GetWeightByIdx(validators.GetIdx(b.ValidatorID))) - int(validators.GetWeightByIdx(validators.GetIdx(a.ValidatorID)))
 	})

--- a/consensus/dagindexer/strongly_reach.go
+++ b/consensus/dagindexer/strongly_reach.go
@@ -77,7 +77,7 @@ func (vi *Index) StronglyReach(aID, bID consensus.EventHash) bool {
 			yes.CountVoteByIndex(creatorIdx)
 		}
 	}
-	return yes.HasQuorum()
+	return yes.QuorumReached()
 }
 
 func (vi *Index) StronglyReachProgress(aID, bID consensus.EventHash, candidateParents, chosenParents consensus.EventHashes) (*consensus.WeightCounter, []*consensus.WeightCounter) {

--- a/consensus/dagindexer/strongly_reach_test.go
+++ b/consensus/dagindexer/strongly_reach_test.go
@@ -862,9 +862,9 @@ func TestStronglyReachProgressCheater(t *testing.T) {
 
 	chosenRes, candidatesRes := vi.StronglyReachProgress(named["a03"].ID(), named["c02"].ID(), candidates, chosen)
 
-	assertar.False(chosenRes.HasQuorum())
+	assertar.False(chosenRes.QuorumReached())
 	for _, c := range candidatesRes {
-		assertar.False(c.HasQuorum())
+		assertar.False(c.QuorumReached())
 	}
 }
 
@@ -906,10 +906,10 @@ func TestStronglyReachProgressOnlyGloballySeenEquivocation(t *testing.T) {
 
 	chosenRes, candidatesRes := vi.StronglyReachProgress(named["a01"].ID(), named["c00"].ID(),
 		[]consensus.EventHash{named["c12"].ID()}, []consensus.EventHash{named["a00"].ID(), named["b01"].ID()})
-	assertar.True(chosenRes.HasQuorum())
+	assertar.True(chosenRes.QuorumReached())
 	// NOTE!!! if the logic supported equivocation seen only globally, this would be false!
 	// This is not a concern at the moment, since it does not impede the method's use case.
-	assertar.True(candidatesRes[0].HasQuorum())
+	assertar.True(candidatesRes[0].QuorumReached())
 }
 
 // Checks panic on missing events.

--- a/consensus/stake.go
+++ b/consensus/stake.go
@@ -24,8 +24,10 @@ type (
 		validators   Validators
 		alreadyVoted []bool // ValidatorIdx -> bool
 
-		quorum, antiQuorum Weight
-		sum, antiSum       Weight
+		quorum     Weight
+		antiQuorum Weight
+		sum        Weight
+		antiSum    Weight
 	}
 )
 
@@ -49,7 +51,7 @@ func (s *WeightCounter) CountVoteByID(v ValidatorID) bool {
 	return s.CountVoteByIndex(validatorIdx)
 }
 
-// CountVoteByIndex increases the vote sum by validator's weight if the validator hasn't voted before, returning the status of the vote
+// CountVoteByIndex increases the vote sum by validator's weight if the validator has not voted before, returning the status of the vote
 func (s *WeightCounter) CountVoteByIndex(validatorIdx ValidatorIndex) bool {
 	if s.alreadyVoted[validatorIdx] {
 		return false
@@ -65,7 +67,7 @@ func (s *WeightCounter) CountAntiVoteByID(v ValidatorID) bool {
 	return s.CountAntiVoteByIndex(validatorIdx)
 }
 
-// CountVoteByIndex increases the anti vote sum by validator's weight if the validator hasn't voted before, returning the status of the vote
+// CountVoteByIndex increases the anti vote sum by validator's weight if the validator has not voted before, returning the status of the vote
 func (s *WeightCounter) CountAntiVoteByIndex(validatorIdx ValidatorIndex) bool {
 	if s.alreadyVoted[validatorIdx] {
 		return false

--- a/consensus/stake.go
+++ b/consensus/stake.go
@@ -24,12 +24,11 @@ type (
 		validators   Validators
 		alreadyVoted []bool // ValidatorIdx -> bool
 
-		quorum Weight
-		sum    Weight
+		quorum, antiQuorum Weight
+		sum, antiSum       Weight
 	}
 )
 
-// NewCounter constructor.
 func (vv Validators) NewCounter() *WeightCounter {
 	return newWeightCounter(vv)
 }
@@ -38,18 +37,19 @@ func newWeightCounter(vv Validators) *WeightCounter {
 	return &WeightCounter{
 		validators:   vv,
 		quorum:       vv.Quorum(),
+		antiQuorum:   vv.TotalWeight() - vv.Quorum(),
 		alreadyVoted: make([]bool, vv.Len()),
 		sum:          0,
+		antiSum:      0,
 	}
 }
 
-// CountVoteByID validator and return true if it hadn't counted before.
 func (s *WeightCounter) CountVoteByID(v ValidatorID) bool {
 	validatorIdx := s.validators.GetIdx(v)
 	return s.CountVoteByIndex(validatorIdx)
 }
 
-// CountVoteByIndex validator and return true if it hadn't counted before.
+// CountVoteByIndex increases the vote sum by validator's weight if the validator hasn't voted before, returning the status of the vote
 func (s *WeightCounter) CountVoteByIndex(validatorIdx ValidatorIndex) bool {
 	if s.alreadyVoted[validatorIdx] {
 		return false
@@ -60,17 +60,41 @@ func (s *WeightCounter) CountVoteByIndex(validatorIdx ValidatorIndex) bool {
 	return true
 }
 
-// HasQuorum achieved.
-func (s *WeightCounter) HasQuorum() bool {
+func (s *WeightCounter) CountAntiVoteByID(v ValidatorID) bool {
+	validatorIdx := s.validators.GetIdx(v)
+	return s.CountAntiVoteByIndex(validatorIdx)
+}
+
+// CountVoteByIndex increases the anti vote sum by validator's weight if the validator hasn't voted before, returning the status of the vote
+func (s *WeightCounter) CountAntiVoteByIndex(validatorIdx ValidatorIndex) bool {
+	if s.alreadyVoted[validatorIdx] {
+		return false
+	}
+	s.alreadyVoted[validatorIdx] = true
+
+	s.antiSum += s.validators.GetWeightByIdx(validatorIdx)
+	return true
+}
+
+func (s *WeightCounter) QuorumReached() bool {
 	return s.sum >= s.quorum
 }
 
-// Sum of counted weights.
+// Anti Quorum denotes the weighted sum of validators that didn't vote towards the quorum.
+// It enables reaching early quorum decisions when the threshold (TotalValidatorWeight - Quorum) has been surpassed,
+// leveraging the fact that the quorum can't be reached no matter how validators vote in future.
+func (s *WeightCounter) AntiQuorumReached() bool {
+	return s.antiSum > s.antiQuorum
+}
+
 func (s *WeightCounter) Sum() Weight {
 	return s.sum
 }
 
-// NumCounted of validators
+func (s *WeightCounter) AntiSum() Weight {
+	return s.antiSum
+}
+
 func (s *WeightCounter) NumCounted() int {
 	num := 0
 	for _, counted := range s.alreadyVoted {

--- a/consensus/stake_test.go
+++ b/consensus/stake_test.go
@@ -24,23 +24,57 @@ func TestStakeCounting_ConsistentSumAndQuorumReached(t *testing.T) {
 		if got := weightCounter.Sum(); sumWeight != got {
 			t.Fatalf("incosistent weight sum while voting, expected: %d, got: %d", sumWeight, got)
 		}
-		if want, got := sumWeight >= quorumWeight, weightCounter.HasQuorum(); want != got {
-			t.Fatalf("unexpected quorum achieved status, quorumWeight := %d, collected weight: %d, expected: %t, got: %t", quorumWeight, sumWeight, want, got)
+		if want, got := sumWeight >= quorumWeight, weightCounter.QuorumReached(); want != got {
+			t.Fatalf("unexpected quorum achieved status, quorumWeight := %d, collected weight: %d, quorum expected status: %t, got: %t", quorumWeight, sumWeight, want, got)
+		}
+	}
+}
+
+func TestStakeCounting_ConsistentSumAndAntiQuorumReached(t *testing.T) {
+	validators, weightCounter := validatorsAndCounterSample(100)
+	antiSum := Weight(0)
+	antiQuorumWeight := validators.TotalWeight() - validators.Quorum()
+	for _, validatorID := range validators.IDs() {
+		// Alternate for variety
+		if validatorID%2 == 0 {
+			weightCounter.CountAntiVoteByIndex(validators.GetIdx(validatorID))
+		} else {
+			weightCounter.CountAntiVoteByID(validatorID)
+		}
+		if validatorID%5 == 0 {
+			// duplicate vote for every 5th - should not affect the voting process
+			weightCounter.CountAntiVoteByID(validatorID)
+		}
+		antiSum += validators.GetWeightByIdx(validators.GetIdx(validatorID))
+		if got := weightCounter.AntiSum(); antiSum != got {
+			t.Fatalf("incosistent weight sum while voting, expected: %d, got: %d", antiSum, got)
+		}
+		if want, got := antiSum > antiQuorumWeight, weightCounter.AntiQuorumReached(); want != got {
+			t.Fatalf("unexpected antiQuorum achieved status, antiQuorumWeight := %d, collected weight: %d, antiQuorum expected status: %t, got: %t", antiQuorumWeight, antiSum, want, got)
 		}
 	}
 }
 
 func TestStakeCounting_VotesAlreadyCounted(t *testing.T) {
-	validators, weightCounter := validatorsAndCounterSample(100)
+	validators, weightCounter := validatorsAndCounterSample(200)
 
 	for _, validatorID := range validators.IDs() {
 		// Count even IDs through ID and odd ones through Index
 		var notCountedBefore bool
-		if validatorID%2 == 0 {
-			notCountedBefore = weightCounter.CountVoteByID(validatorID)
+		if validatorID%3 == 0 {
+			if validatorID%2 == 0 {
+				notCountedBefore = weightCounter.CountVoteByID(validatorID)
+			} else {
+				notCountedBefore = weightCounter.CountVoteByIndex(validators.GetIdx(validatorID))
+			}
 		} else {
-			notCountedBefore = weightCounter.CountVoteByIndex(validators.GetIdx(validatorID))
+			if validatorID%2 == 0 {
+				notCountedBefore = weightCounter.CountAntiVoteByID(validatorID)
+			} else {
+				notCountedBefore = weightCounter.CountAntiVoteByIndex(validators.GetIdx(validatorID))
+			}
 		}
+
 		if !notCountedBefore {
 			t.Errorf("notCountedBefore expected to be false for ValidatorID: %d", validatorID)
 		}
@@ -61,21 +95,58 @@ func TestStakeCounting_VotesAlreadyCounted(t *testing.T) {
 }
 
 func TestStake_NumCountedConsistent(t *testing.T) {
-	validators, weightCounter := validatorsAndCounterSample(100)
+	validators, weightCounter := validatorsAndCounterSample(200)
 	pickedValidators := validators.IDs()
 	rand.Shuffle(len(pickedValidators), func(i, j int) { pickedValidators[i], pickedValidators[j] = pickedValidators[j], pickedValidators[i] })
 	pickedValidators = pickedValidators[0 : len(pickedValidators)/3]
 
 	for _, validatorID := range pickedValidators {
 		// Alternate for variety
-		if validatorID%2 == 0 {
-			weightCounter.CountVoteByIndex(validators.GetIdx(validatorID))
+		if validatorID%3 == 0 {
+			if validatorID%2 == 0 {
+				weightCounter.CountVoteByID(validatorID)
+			} else {
+				weightCounter.CountVoteByIndex(validators.GetIdx(validatorID))
+			}
 		} else {
-			weightCounter.CountVoteByID(validatorID)
+			if validatorID%2 == 0 {
+				weightCounter.CountAntiVoteByID(validatorID)
+			} else {
+				weightCounter.CountAntiVoteByIndex(validators.GetIdx(validatorID))
+			}
 		}
 	}
 	if want, got := len(pickedValidators), weightCounter.NumCounted(); want != got {
 		t.Fatalf("unexpected total number of votes, expected: %d, got: %d", want, got)
+	}
+}
+
+func TestStake_VotesCounterComplente(t *testing.T) {
+	validators, weightCounter := validatorsAndCounterSample(200)
+	pickedValidators := validators.IDs()
+	rand.Shuffle(len(pickedValidators), func(i, j int) { pickedValidators[i], pickedValidators[j] = pickedValidators[j], pickedValidators[i] })
+	pickedValidators = pickedValidators[0 : len(pickedValidators)/3]
+	totalVoteWeight := Weight(0)
+
+	for _, validatorID := range pickedValidators {
+		// Alternate for variety
+		if validatorID%3 == 0 {
+			if validatorID%2 == 0 {
+				weightCounter.CountVoteByID(validatorID)
+			} else {
+				weightCounter.CountVoteByIndex(validators.GetIdx(validatorID))
+			}
+		} else {
+			if validatorID%2 == 0 {
+				weightCounter.CountAntiVoteByID(validatorID)
+			} else {
+				weightCounter.CountAntiVoteByIndex(validators.GetIdx(validatorID))
+			}
+		}
+		totalVoteWeight += validators.GetWeightByIdx(validators.GetIdx(validatorID))
+		if want, got := totalVoteWeight, weightCounter.Sum()+weightCounter.AntiSum(); want != got {
+			t.Fatalf("unexpected total weight of votes, expected: %d, got: %d, sum: %d, antiSum: %d", want, got, weightCounter.Sum(), weightCounter.AntiSum())
+		}
 	}
 }
 


### PR DESCRIPTION
This PR introduces a simple concept of `Anti Quorum` denoting a threshold that has to be crossed by validators voting negatively, in order to guarantee a negative voting decision. This threshold is essentially a complement Quorum's complement in the sum of total validator stake. 
- Stake tests have been extended to include and test AntiQuorum.
- `stronglyReachableByQuorum` now leverages the fact that the majority of decision votes in a Sonic Consensus fail, stopping the vote when Anti Quorum is reached. To optimize the approach further, the frame bases are traversed in a descending order of their respective validator stake, making the early-fail and early-succeed decisions occurr with minimal number of `StronglyReach` calls.

Testing done:
All unit tests pass
Client build with the PR branch passes epochs [1, 1100] and [6720, 6970] and produces a correct head.